### PR TITLE
BT-108 updated dependencies on cdshooks-wih to the right ones

### DIFF
--- a/cdshooks-wih/pom.xml
+++ b/cdshooks-wih/pom.xml
@@ -31,14 +31,25 @@
   </properties>
 
  <dependencies>
-   	<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
     <dependency>
-    	<groupId>io.elimu.a2d2</groupId>
-    	<artifactId>kie-based-services</artifactId>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+    	<groupId>org.kie</groupId>
+    	<artifactId>kie-api</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-core</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-dmn-core</artifactId>
+        <version>${kie.version}</version>
+	<scope>test</scope>
     </dependency>
     <dependency>
     	<groupId>io.elimu.a2d2</groupId>


### PR DESCRIPTION
Putting kie-based-services as a test dependency is not correct, because it is an internal component in the runtime that the WIH does not depend on directly. Instead, we need to add org.kie:kie-api as a dependency for the WorkItemHandler class dependency, and drools-core/kie-dmn-core as test dependencies for the test requirements 