### PR TITLE
Helper to transform DSTU2/3 to R4

### DIFF
--- a/fhir-helpers/pom.xml
+++ b/fhir-helpers/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2018-2020 Elimu Informatics
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http:  www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>io.elimu.a2d2</groupId>
+	<artifactId>fhir-helpers</artifactId>
+	<version>0.0.1</version>
+	<packaging>jar</packaging>
+	<name>fhir-helpers</name>
+	<url>http://maven.apache.org</url>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<hapi.fhir.version>3.8.0</hapi.fhir.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-structures-dstu2</artifactId>
+			<version>${hapi.fhir.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-structures-dstu3</artifactId>
+			<version>${hapi.fhir.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-structures-r4</artifactId>
+			<version>${hapi.fhir.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-client</artifactId>
+			<version>${hapi.fhir.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-base</artifactId>
+			<version>${hapi.fhir.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-utilities</artifactId>
+			<version>${hapi.fhir.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-converter</artifactId>
+			<version>${hapi.fhir.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-structures-hl7org-dstu2</artifactId>
+			<version>${hapi.fhir.version}</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/fhir-helpers/src/main/java/io/elimu/a2d2/fhir/FhirTransformHelper.java
+++ b/fhir-helpers/src/main/java/io/elimu/a2d2/fhir/FhirTransformHelper.java
@@ -1,0 +1,115 @@
+package io.elimu.a2d2.fhir;
+
+import java.text.SimpleDateFormat;
+
+import org.hl7.fhir.convertors.NullVersionConverterAdvisor40;
+import org.hl7.fhir.convertors.VersionConvertor_10_40;
+import org.hl7.fhir.convertors.VersionConvertor_30_40;
+
+import ca.uhn.fhir.context.FhirContext;
+
+public class FhirTransformHelper {
+
+	private static final SimpleDateFormat FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+	
+	private static org.hl7.fhir.r4.model.MedicationRequest transformMedicationOrder(ca.uhn.fhir.model.dstu2.resource.MedicationOrder mo) {
+		org.hl7.fhir.r4.model.MedicationRequest retval = new org.hl7.fhir.r4.model.MedicationRequest();
+		retval.setId(mo.getId() != null ? mo.getIdElement().getIdPart() : null);
+		retval.getMeta().setVersionId(mo.getMeta().getVersionId());
+		retval.getMeta().setLastUpdated(mo.getMeta().getLastUpdated());
+		retval.setAuthoredOn(mo.getDateWritten());
+		retval.setStatus(org.hl7.fhir.r4.model.MedicationRequest.MedicationRequestStatus.fromCode(mo.getStatus()));
+		if (mo.getMedication() != null) {
+			retval.getMedicationReference().setReference(((ca.uhn.fhir.model.dstu2.composite.ResourceReferenceDt) mo.getMedication()).getReference().getValue());
+			retval.getMedicationReference().setDisplay(((ca.uhn.fhir.model.dstu2.composite.ResourceReferenceDt) mo.getMedication()).getDisplay().getValue());
+		}
+		boolean alreadyDated = false;
+		for (ca.uhn.fhir.model.dstu2.resource.MedicationOrder.DosageInstruction di : mo.getDosageInstruction()) {
+			org.hl7.fhir.r4.model.Dosage di4 = retval.addDosageInstruction();
+			if (!alreadyDated) {
+				if (mo.getDateWritten() != null) {
+					di.getAdditionalInstructions().addCoding().setSystem("urn:oid:date-written").setDisplay(FORMAT.format(mo.getDateWritten()));
+				}
+				if (mo.getDateEnded() != null) {
+					di.getAdditionalInstructions().addCoding().setSystem("urn:oid:date-ended").setDisplay(FORMAT.format(mo.getDateWritten()));
+				}
+			}
+			alreadyDated = true;
+			di4.setText(di.getText());
+			if (di.getDose() != null) {
+				di4.getDoseAndRateFirstRep().getDoseQuantity().setValue(((ca.uhn.fhir.model.dstu2.composite.QuantityDt) di.getDose()).getValue());
+			}
+			for (ca.uhn.fhir.model.dstu2.composite.CodingDt c : di.getRoute().getCoding()) {
+				di4.getRoute().addCoding().setSystem(c.getSystem()).setCode(c.getCode()).setDisplay(c.getDisplay());
+			}
+		}
+		retval.getDispenseRequest().getQuantity().setValue(mo.getDispenseRequest().getQuantity().getValue()).setUnit(mo.getDispenseRequest().getQuantity().getUnit());
+		for (ca.uhn.fhir.model.dstu2.composite.CodingDt c : mo.getSubstitution().getReason().getCoding()) {
+			retval.getSubstitution().getReason().addCoding().setSystem(c.getSystem()).setCode(c.getCode()).setDisplay(c.getDisplay());
+		}
+		retval.getSubject().setReference(mo.getPatient().getReference().getIdPart()).setDisplay(mo.getPatient().getDisplay().getValue());
+		retval.getPerformer().setReference(mo.getPrescriber().getReference().getIdPart()).setDisplay(mo.getPrescriber().getDisplay().getValue());
+		return retval;
+	}
+	
+	public static org.hl7.fhir.r4.model.AllergyIntolerance transformAllergyIntolerance(ca.uhn.fhir.model.dstu2.resource.AllergyIntolerance ai) {
+		if (ai == null) {
+			return null;
+		}
+		org.hl7.fhir.r4.model.AllergyIntolerance retval = new org.hl7.fhir.r4.model.AllergyIntolerance();
+		retval.setId(ai.getId() == null ? null : ai.getId().getIdPart());
+		retval.getMeta().setVersionId(ai.getMeta().getVersionId());
+		retval.getMeta().setLastUpdated(ai.getMeta().getLastUpdated());
+		if (ai.getText() != null && ai.getText().getDiv() != null) {
+			retval.getText().getDiv().setContent(ai.getText().getDiv().getValue());
+		}
+		if (ai.getOnset() != null) {
+			retval.setOnset(new org.hl7.fhir.r4.model.DateTimeType(ai.getOnset()));
+		}
+		retval.getRecorder().setReference(ai.getRecorder().getReference().getValue());
+		retval.getRecorder().setDisplay(ai.getRecorder().getDisplay().getValue());
+		retval.getPatient().setReference(ai.getPatient().getReference().getValue());
+		retval.setLastOccurrence(ai.getLastOccurence());
+		for (ca.uhn.fhir.model.dstu2.resource.AllergyIntolerance.Reaction r : ai.getReaction()) {
+			org.hl7.fhir.r4.model.AllergyIntolerance.AllergyIntoleranceReactionComponent r4 = retval.addReaction();
+			for (ca.uhn.fhir.model.dstu2.composite.CodingDt c : r.getSubstance().getCoding()) {
+				r4.getSubstance().addCoding().setSystem(c.getSystem()).setCode(c.getCode()).setDisplay(c.getDisplay());
+			}
+			for (ca.uhn.fhir.model.dstu2.composite.CodeableConceptDt cpt : r.getManifestation()) {
+				org.hl7.fhir.r4.model.CodeableConcept c4 = r4.addManifestation();
+				for (ca.uhn.fhir.model.dstu2.composite.CodingDt c : cpt.getCoding()) {
+					c4.addCoding().setSystem(c.getSystem()).setCode(c.getCode()).setDisplay(c.getDisplay());
+				}
+			}
+			r4.setSeverity(org.hl7.fhir.r4.model.AllergyIntolerance.AllergyIntoleranceSeverity.fromCode(r.getSeverity()));
+			if (r.getCertainty() != null) {
+				r4.setDescription("Certainty: " + r.getCertainty());
+			}
+		}
+		for (ca.uhn.fhir.model.dstu2.composite.CodingDt c : ai.getSubstance().getCoding()) {
+			retval.getCode().addCoding().setSystem(c.getSystem()).setCode(c.getCode()).setDisplay(c.getDisplay());
+		}
+		return retval;
+	}
+
+	public static org.hl7.fhir.r4.model.Resource transformDstu3Resource(org.hl7.fhir.dstu3.model.Resource v3res) {
+		return VersionConvertor_30_40.convertResource(v3res, true);
+	}
+
+	public static org.hl7.fhir.r4.model.Resource transformDstu2Resource(ca.uhn.fhir.model.dstu2.resource.BaseResource v2resource) {
+		if (v2resource instanceof ca.uhn.fhir.model.dstu2.resource.AllergyIntolerance) {
+			return transformAllergyIntolerance((ca.uhn.fhir.model.dstu2.resource.AllergyIntolerance) v2resource);
+		} else if (v2resource instanceof ca.uhn.fhir.model.dstu2.resource.MedicationOrder) {
+			return transformMedicationOrder((ca.uhn.fhir.model.dstu2.resource.MedicationOrder) v2resource);
+		}
+		
+		String dstu2json = FhirContext.forDstu2().newJsonParser().encodeResourceToString(v2resource);
+		//For Patient: AdministrativeGender will receive Female, Male, and expect female, male. We need to pre-convert
+		dstu2json = dstu2json.replaceAll("\"Female\"", "\"female\"");
+		dstu2json = dstu2json.replaceAll("\"Male\"", "\"male\"");
+		//For Mer
+		org.hl7.fhir.instance.model.Resource v2hl7resource = (org.hl7.fhir.instance.model.Resource) FhirContext.forDstu2Hl7Org().newJsonParser().parseResource(dstu2json);
+		org.hl7.fhir.r4.model.Resource v4resource = new VersionConvertor_10_40(new NullVersionConverterAdvisor40()).convertResource(v2hl7resource);
+		return v4resource;
+	}
+}

--- a/fhir-helpers/src/test/java/io/elimu/a2d2/fhir/FhirTransformHelperTest.java
+++ b/fhir-helpers/src/test/java/io/elimu/a2d2/fhir/FhirTransformHelperTest.java
@@ -1,0 +1,56 @@
+package io.elimu.a2d2.fhir;
+
+import java.io.InputStream;
+
+import org.hl7.fhir.r4.model.Resource;
+import org.junit.Assert;
+import org.junit.Test;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.dstu2.resource.BaseResource;
+
+public class FhirTransformHelperTest {
+
+	@Test
+	public void testTransformAllergyIntoleranceV2toV4() throws Exception {
+		InputStream input = getClass().getResourceAsStream("/allergy-intolerance.json");
+		BaseResource resv2 = (BaseResource) FhirContext.forDstu2().newJsonParser().parseResource(input);
+		Resource resv4 = FhirTransformHelper.transformDstu2Resource(resv2);
+		Assert.assertNotNull(resv4);
+	}
+
+	@Test
+	public void testTransformMedicationOrderV2toV4() {
+		InputStream input = getClass().getResourceAsStream("/medication-order.json");
+		BaseResource resv2 = (BaseResource) FhirContext.forDstu2().newJsonParser().parseResource(input);
+		Resource resv4 = FhirTransformHelper.transformDstu2Resource(resv2);
+		Assert.assertNotNull(resv4);
+	}
+
+	@Test
+	public void testTransformConditionV2toV4() {
+		InputStream input = getClass().getResourceAsStream("/condition.json");
+		BaseResource resv2 = (BaseResource) FhirContext.forDstu2().newJsonParser().parseResource(input);
+		Resource resv4 = FhirTransformHelper.transformDstu2Resource(resv2);
+		Assert.assertNotNull(resv4);
+
+	}
+
+	@Test
+	public void testTransformPatientV2toV4() {
+		InputStream input = getClass().getResourceAsStream("/patient.json");
+		BaseResource resv2 = (BaseResource) FhirContext.forDstu2().newJsonParser().parseResource(input);
+		Resource resv4 = FhirTransformHelper.transformDstu2Resource(resv2);
+		Assert.assertNotNull(resv4);
+	}
+
+	@Test
+	public void testTransformQuestionnaireResponseV3toV4() {
+		InputStream input = getClass().getResourceAsStream("/questionnaire-response.json");
+		BaseResource resv2 = (BaseResource) FhirContext.forDstu2().newJsonParser().parseResource(input);
+		Resource resv4 = FhirTransformHelper.transformDstu2Resource(resv2);
+		Assert.assertNotNull(resv4);
+
+	}
+
+}

--- a/fhir-helpers/src/test/resources/allergy-intolerance.json
+++ b/fhir-helpers/src/test/resources/allergy-intolerance.json
@@ -1,0 +1,79 @@
+{
+  "resourceType": "AllergyIntolerance",
+  "id": "87",
+  "meta": {
+    "versionId": "4",
+    "lastUpdated": "2020-01-10T05:32:16.000+00:00"
+  },
+  "text": {
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"></div>"
+  },
+  "onset": "2016-12-16T15:55:00",
+  "recorder": {
+    "display": "Dr James"
+  },
+  "patient": {
+    "fhir_comments": [
+      "   the patient that actually has the risk of adverse reaction   "
+    ],
+    "reference": "Patient/1"
+  },
+  "substance": {
+    "fhir_comments": [
+      "   subtance - either coded, or text. A few times, \n    there's a full description of a complex substance - in these caes, use the\n    extension [url] to refer to a Substance resource   "
+    ],
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "406466009"
+      }
+    ]
+  },
+  "lastOccurence": "2016-12-07T01:05:00.000Z",
+  "reaction": [
+    {
+      "fhir_comments": [
+        " past events. There's no claim that this is all the events, and \n that should not be assumed "
+      ],
+      "substance": {
+        "fhir_comments": [
+          " \n It's possible to list specific things to which the patient responded,\n e.g. chocolate (that happened to contain cashew nuts). This event has\n such a specific substance. Note that systems should ensure that what\n goes in here does not conflict with the substance above, and systems\n processing the data can be sure that what is here does not contravene\n the substance above\n "
+        ],
+        "coding": [
+          {
+            "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+            "code": "3092008"
+          }
+        ]
+      },
+      "manifestation": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "display": "Anaphylactic"
+            }
+          ]
+        }
+      ],
+      "severity": "moderate"
+    },
+    {
+      "certainty": "likely",
+      "_certainty": {
+        "fhir_comments": [
+          " this was the first occurrence "
+        ]
+      },
+      "manifestation": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/fhir-helpers/src/test/resources/condition.json
+++ b/fhir-helpers/src/test/resources/condition.json
@@ -1,0 +1,37 @@
+{
+  "resourceType": "Condition",
+  "id": "608",
+  "meta": {
+    "versionId": "2",
+    "lastUpdated": "2017-02-27T13:44:19.000+00:00"
+  },
+  "text": {
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"></div>"
+  },
+  "patient": {
+    "reference": "Patient/2"
+  },
+  "asserter": {
+    "display": "Dr.Robb"
+  },
+  "code": {
+    "coding": [
+      {
+        "system": "ICD9",
+        "code": "906.0",
+        "display": "Late effect of open wound of head, neck, and trunk"
+      }
+    ],
+    "text": "Late effect of open wound of head, neck, and trunk (ICD9 Code : 906.0 )"
+  },
+  "category": {
+    "coding": [
+      {
+        "system": " http://hl7.org/fhir/condition-category",
+        "code": "symptom",
+        "display": "Symptom"
+      }
+    ]
+  },
+  "onsetDateTime": "2017-01-03T03:35:00.000Z"
+}

--- a/fhir-helpers/src/test/resources/medication-order.json
+++ b/fhir-helpers/src/test/resources/medication-order.json
@@ -1,0 +1,41 @@
+{
+  "resourceType": "MedicationOrder",
+  "id": "457",
+  "meta": {
+    "versionId": "3",
+    "lastUpdated": "2017-01-10T08:59:40.000+00:00"
+  },
+  "dateWritten": "2017-01-05T00:00:00",
+  "status": "active",
+  "dateEnded": "2017-01-31T21:45:00",
+  "patient": {
+    "reference": "Patient/435"
+  },
+  "prescriber": {
+    "display": "Dr.Mark Antony"
+  },
+  "medicationReference": {
+    "reference": "Medication/602",
+    "display": "CANCIDAS (Injectable)"
+  },
+  "dosageInstruction": [
+    {
+      "text": "every day",
+      "route": {
+        "coding": [
+          {
+            "display": "Injectable"
+          }
+        ]
+      },
+      "doseQuantity": {
+        "value": 1
+      }
+    }
+  ],
+  "dispenseRequest": {
+    "quantity": {
+      "value": 15
+    }
+  }
+}

--- a/fhir-helpers/src/test/resources/patient.json
+++ b/fhir-helpers/src/test/resources/patient.json
@@ -1,0 +1,123 @@
+{
+  "resourceType": "Patient",
+  "id": "2252",
+  "meta": {
+    "versionId": "17",
+    "lastUpdated": "2017-06-08T08:50:42.000+00:00"
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div class=\"hapiHeaderText\">Ms. Mary <b>CONTRARY </b></div><table class=\"hapiPropertyTable\"><tbody><tr><td>Identifier</td><td>60418273</td></tr><tr><td>Address</td><td><span>168 Florence Street </span><br/><span>Springfield </span><span>IL </span><span>USA </span></td></tr><tr><td>Date of birth</td><td><span>29 October 1989</span></td></tr></tbody></table></div>"
+  },
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/v2/0203",
+            "code": "MR"
+          }
+        ]
+      },
+      "value": "60418273"
+    },
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/v2/0203",
+            "code": "PLAC"
+          }
+        ]
+      },
+      "value": "12345"
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "use": "official",
+      "family": [
+        "Contrary"
+      ],
+      "given": [
+        "Mary"
+      ],
+      "prefix": [
+        "Ms."
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "708-555-1212",
+      "use": "mobile"
+    },
+    {
+      "system": "phone",
+      "value": "708-555-6666",
+      "use": "home"
+    }
+  ],
+  "gender": "Female",
+  "birthDate": "1989-10-29",
+  "deceasedBoolean": false,
+  "address": [
+    {
+      "use": "home",
+      "line": [
+        "168 Florence Street"
+      ],
+      "city": "Springfield",
+      "state": "IL",
+      "postalCode": "60321",
+      "country": "USA"
+    }
+  ],
+  "maritalStatus": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/v3/MaritalStatus",
+        "code": "S",
+        "display": "Never Married"
+      }
+    ]
+  },
+  "multipleBirthBoolean": false,
+  "contact": [
+    {
+      "relationship": [
+        {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/patient-contact-relationship",
+              "code": "family",
+              "display": "Family"
+            }
+          ]
+        }
+      ],
+      "name": {
+        "use": "usual",
+        "text": "Terry Contrary"
+      },
+      "telecom": [
+        {
+          "system": "phone",
+          "value": "708-555-4321",
+          "use": "home"
+        }
+      ]
+    }
+  ],
+  "communication": [
+    {
+      "language": {
+        "text": "Engliish (UK)"
+      }
+    }
+  ]
+}

--- a/fhir-helpers/src/test/resources/questionnaire-response.json
+++ b/fhir-helpers/src/test/resources/questionnaire-response.json
@@ -1,0 +1,214 @@
+{
+    "resourceType": "QuestionnaireResponse",
+    "id": "704",
+    "meta": {
+        "versionId": "1",
+        "lastUpdated": "2020-04-03T15:53:41.431+00:00"
+    },
+    "questionnaire": {
+        "identifier": {
+            "system": "http://loinc.org",
+            "value": "44249-1"
+        }
+    },
+    "status": "completed",
+    "subject": {
+        "reference": "Patient/702"
+    },
+    "authored": "2019-03-25T12:13:00-04:00",
+    "author": {
+        "reference": "Patient/702"
+    },
+    "item": [
+        {
+            "linkId": "1",
+            "definition": "http://loinc.orgfhir/DataElement/44250-9",
+            "text": "Little interest or pleasure in doing things?",
+            "answer": [
+                {
+                    "valueCoding": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/iso21090-CO-value",
+                                "valueDecimal": 0
+                            }
+                        ],
+                        "system": "http://loinc.org",
+                        "code": "LA6568-5",
+                        "display": "Yes"
+                    }
+                }
+            ]
+        },
+        {
+            "linkId": "2",
+            "definition": "http://loinc.orgfhir/DataElement/44255-8",
+            "text": "Feeling down, depressed, or hopeless?",
+            "answer": [
+                {
+                    "valueCoding": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/iso21090-CO-value",
+                                "valueDecimal": 0
+                            }
+                        ],
+                        "system": "http://loinc.org",
+                        "code": "LA6568-5",
+                        "display": "Yes"
+                    }
+                }
+            ]
+        },
+        {
+            "linkId": "3",
+            "definition": "http://loinc.orgfhir/DataElement/44259-0",
+            "text": "Trouble falling or staying asleep, or sleeping too much?",
+            "answer": [
+                {
+                    "valueCoding": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/iso21090-CO-value",
+                                "valueDecimal": 3
+                            }
+                        ],
+                        "system": "http://loinc.org",
+                        "code": "LA6571-9",
+                        "display": "Yes"
+                    }
+                }
+            ]
+        },
+        {
+            "linkId": "4",
+            "definition": "http://loinc.orgfhir/DataElement/44254-1",
+            "text": "Feeling tired or having little energy?",
+            "answer": [
+                {
+                    "valueCoding": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/iso21090-CO-value",
+                                "valueDecimal": 2
+                            }
+                        ],
+                        "system": "http://loinc.org",
+                        "code": "LA6570-1",
+                        "display": "Yes"
+                    }
+                }
+            ]
+        },
+        {
+            "linkId": "5",
+            "definition": "http://loinc.orgfhir/DataElement/44251-7",
+            "text": "Poor appetite or overeating?",
+            "answer": [
+                {
+                    "valueCoding": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/iso21090-CO-value",
+                                "valueDecimal": 1
+                            }
+                        ],
+                        "system": "http://loinc.org",
+                        "code": "LA6569-3",
+                        "display": "Yes"
+                    }
+                }
+            ]
+        },
+        {
+            "linkId": "6",
+            "definition": "http://loinc.orgfhir/DataElement/44258-2",
+            "text": "Feeling bad about yourself - or that you are a failure or have let yourself or your family down?",
+            "answer": [
+                {
+                    "valueCoding": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/iso21090-CO-value",
+                                "valueDecimal": 2
+                            }
+                        ],
+                        "system": "http://loinc.org",
+                        "code": "LA6570-1",
+                        "display": "Yes"
+                    }
+                }
+            ]
+        },
+        {
+            "linkId": "7",
+            "definition": "http://loinc.orgfhir/DataElement/44252-5",
+            "text": "Trouble concentrating on things, such as reading the newspaper or watching television?",
+            "answer": [
+                {
+                    "valueCoding": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/iso21090-CO-value",
+                                "valueDecimal": 1
+                            }
+                        ],
+                        "system": "http://loinc.org",
+                        "code": "LA6569-3",
+                        "display": "Yes"
+                    }
+                }
+            ]
+        },
+        {
+            "linkId": "8",
+            "definition": "http://loinc.orgfhir/DataElement/44253-3",
+            "text": "Moving or speaking so slowly that other people could have noticed? Or so fidgety or restless that you been moving a lot more than usual?",
+            "answer": [
+                {
+                    "valueCoding": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/iso21090-CO-value",
+                                "valueDecimal": 0
+                            }
+                        ],
+                        "system": "http://loinc.org",
+                        "code": "LA6568-5",
+                        "display": "Yes"
+                    }
+                }
+            ]
+        },
+        {
+            "linkId": "9",
+            "definition": "http://loinc.orgfhir/DataElement/44260-8",
+            "text": "Thoughts that you would be better off dead, or thoughts of hurting yourself in some way?",
+            "answer": [
+                {
+                    "valueCoding": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/iso21090-CO-value",
+                                "valueDecimal": 1
+                            }
+                        ],
+                        "system": "http://loinc.org",
+                        "code": "LA6569-3",
+                        "display": "Yes"
+                    }
+                }
+            ]
+        },
+        {
+            "linkId": "10",
+            "definition": "http://loinc.orgfhir/DataElement/44261-6",
+            "text": "Total PHQ-9 Score",
+            "answer": [
+                {
+                    "valueInteger": 10
+                }
+            ]
+        }
+    ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,10 @@
 		<module>cdshooks-wih</module>
 		<module>web-util</module>
 		<module>fhir-query-helper-dstu2</module>
-    	<module>fhir-query-helper-dstu3</module>
-    	<module>fhir-query-helper-r4</module>
+		<module>fhir-query-helper-dstu3</module>
+		<module>fhir-query-helper-r4</module>
 		<module>fhir-query-helper-base</module>
+		<module>fhir-helpers</module>
 		<module>task-utilities</module>
 		<module>sms-wih</module>
 		<module>a2d2-api</module>


### PR DESCRIPTION
this helper allows us to transform DSTU2 and DSTU3 fhir domain objects into R4 objects. Due to the limitations of the provided converters, this is a workaround for that problem.