### PR TITLE
Adding dependencies needed for FHIR conveters

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -113,6 +113,23 @@
 			<artifactId>fhir-resource-wih</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<!-- Added for phq9-registry converters to work -->
+		<dependency>
+                        <groupId>ca.uhn.hapi.fhir</groupId>
+                        <artifactId>hapi-fhir-utilities</artifactId>
+                        <version>${hapi.fhir.version}</version>
+                </dependency>
+                <dependency>
+                        <groupId>ca.uhn.hapi.fhir</groupId>
+                        <artifactId>hapi-fhir-converter</artifactId>
+                        <version>${hapi.fhir.version}</version>
+                </dependency>
+                <dependency>
+                        <groupId>ca.uhn.hapi.fhir</groupId>
+                        <artifactId>hapi-fhir-structures-hl7org-dstu2</artifactId>
+                        <version>${hapi.fhir.version}</version>
+                </dependency>
+		<!-- END added for phq9-registry converters -->
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>cdshooks-wih</artifactId>


### PR DESCRIPTION
Because the hapi-fhir-base JAR is at webapp level in the classloader, and it uses reflection in the same classloader as it is to transform from one model to the other, we need to add the hapi-fhir-converter and hapi-fhir-structures-hl7org-dstu2 JARs to the app in order for applications to use the FHIR converter without ClassCastExceptions 