### PR TITLE
Updated Dockerfile for ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,12 @@ FROM openjdk:8 as final
 
 WORKDIR /app
 
-ENV HEALTHCHECKURL http://localhost:8080/actuator/health
 ARG JAVA_OPTS
 
 COPY ./a2d2-api/target/a2d2-api.war /app/a2d2-api.war
 COPY --from=maven /usr/src/client_repo /root/.m2/repository
 COPY --from=maven /usr/src/services /app/services
 
-HEALTHCHECK --interval=60s --timeout=30s --start-period=30s --retries=3 CMD curl -f $HEALTHCHECKURL 2>&1 | grep UP || exit 1
-
+EXPOSE 8080
+EXPOSE 8443
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar a2d2-api.war"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,14 @@ FROM openjdk:8 as final
 
 WORKDIR /app
 
+ENV HEALTHCHECKURL http://localhost:8080/actuator/health
 ARG JAVA_OPTS
 
 COPY ./a2d2-api/target/a2d2-api.war /app/a2d2-api.war
 COPY --from=maven /usr/src/client_repo /root/.m2/repository
 COPY --from=maven /usr/src/services /app/services
+
+HEALTHCHECK --interval=60s --timeout=30s --start-period=30s --retries=3 CMD curl -f $HEALTHCHECKURL 2>&1 | grep UP || exit 1
 
 EXPOSE 8080
 EXPOSE 8443


### PR DESCRIPTION
Declared default ports and removed the health check URL which is on 8080, as we are specifying the port and health check on runtime.