### PR TITLE
Null-checking the authHeader, which some services might leave null

### DIFF
--- a/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/ResourceWriteDelegate.java
+++ b/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/ResourceWriteDelegate.java
@@ -63,7 +63,8 @@ public class ResourceWriteDelegate implements WorkItemHandler {
 				}
 
 				if (client != null) {
-					if (!completeworkItem(client, fhirResource, workItemResult, manager, workItem, workItemParam.get("authHeader").toString(),actionType)) {
+					Object auth = workItemParam.get("authHeader");
+					if (!completeworkItem(client, fhirResource, workItemResult, manager, workItem, auth == null ? null : auth.toString(), actionType)) {
 						log.error(serverUrl.toString(), CLIENT_NULL);
 						throw new FhirServerException(serverUrl.toString(), CLIENT_NULL);
 					}


### PR DESCRIPTION
In some services, "authHeader" input is left as null if the FHIR server used has no authorization required (in some internal installations it has been the case). This makes sure that if the param is missing, it will not throw a NullPointerException 