### PR TITLE
FHIR query helpers, status controller, and OAuth utilities update

### DIFF
--- a/a2d2-api/src/main/java/io/elimu/cdshookapi/api/rest/StatusController.java
+++ b/a2d2-api/src/main/java/io/elimu/cdshookapi/api/rest/StatusController.java
@@ -1,0 +1,48 @@
+// Copyright 2018-2020 Elimu Informatics
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.elimu.cdshookapi.api.rest;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.elimu.genericapi.service.RunningServices;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+@RestController
+@Api(tags = {"actuator", "health", "status"})
+public class StatusController {
+
+	@CrossOrigin
+	@RequestMapping(value = "/actuator/health", method = {RequestMethod.POST, RequestMethod.GET, RequestMethod.PUT, RequestMethod.DELETE}, 
+	consumes = "*/*", produces = "*/*")
+	@ApiOperation(value = "Checks health of services", notes = "Checks if all services are up and running already")
+	public void healthCheck(HttpServletRequest request, HttpServletResponse response) {
+		try {
+			boolean started = RunningServices.getInstance().isStarted();
+			response.setStatus(started ? 200 : 503);
+			response.addHeader("Content-Type", "application/json");
+			response.getWriter().println("{\"status\": \"" + (started ? "UP" : "STARTING") + "\"}");
+		} catch (Exception e) { 
+			//no op
+		}
+	}
+}
+

--- a/fhir-query-helper-base/pom.xml
+++ b/fhir-query-helper-base/pom.xml
@@ -27,7 +27,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-base</artifactId>
-	<version>0.0.5</version>
+	<version>0.0.6</version>
 	<description>CDS Helper base</description>
 
 	<properties>

--- a/fhir-query-helper-dstu2/pom.xml
+++ b/fhir-query-helper-dstu2/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-dstu2</artifactId>
-	<version>0.0.5</version>
+	<version>0.0.6</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper</description>
 

--- a/fhir-query-helper-dstu2/src/main/java/io/elimu/a2d2/cds/fhir/helper/QueryingServerHelper.java
+++ b/fhir-query-helper-dstu2/src/main/java/io/elimu/a2d2/cds/fhir/helper/QueryingServerHelper.java
@@ -52,6 +52,32 @@ public class QueryingServerHelper extends QueryingServerHelperBase<QueryingServe
 	public IBaseResource getResourceById(String resourceType, String resourceId) {
 		return getResourceByIdResponse(resourceType, resourceId).getResult();
 	}
+	
+	@Override 
+	public FhirResponse<IBaseResource> fetchServer(final String resourceType, String resourceQuery) {
+		FhirClientWrapper client = clients.next();
+		FhirResponse<IBaseResource> resource = null;
+		log.debug("Fetching {} {} resource using client for version {} ", client.getFhirContext().getVersion().getVersion().name(),
+				resourceType,  client.getFhirContext().getVersion().getVersion().name());
+		resource = runWithInterceptors(new QueryingCallback<IBaseResource>() {
+			@Override
+			@SuppressWarnings("unchecked")
+			public IBaseResource execute(FhirClientWrapper client) {
+				log.debug("Invoking url {}", resourceQuery);
+				try {
+					Class<IBaseResource> clz = (Class<IBaseResource>) Class.forName("ca.uhn.fhir.model.dstu2.resource." + resourceType);
+					return client.fetchResourceFromUrl(clz, resourceQuery);
+				} catch (ClassNotFoundException e) {
+					log.error("ResourceType " + resourceType + " not supported for direct path reading in fhir " + client.getFhirContext().getVersion().getVersion().name());
+					return null;
+				}
+			}
+		}, client);
+		if (resource == null) {
+			return new FhirResponse<>(null, 404, "Not Found");
+		}
+		return resource;
+	}
 
 	@Override
 	public FhirResponse<List<IBaseResource>> queryServer(final String resourceQuery) {

--- a/fhir-query-helper-dstu3/pom.xml
+++ b/fhir-query-helper-dstu3/pom.xml
@@ -26,7 +26,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-dstu3</artifactId>
-	<version>0.0.5</version>
+	<version>0.0.6</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper DSTU3</description>
 

--- a/fhir-query-helper-dstu3/src/main/java/io/elimu/a2d2/cds/fhir/helper/dstu3/QueryingServerHelper.java
+++ b/fhir-query-helper-dstu3/src/main/java/io/elimu/a2d2/cds/fhir/helper/dstu3/QueryingServerHelper.java
@@ -59,6 +59,32 @@ public class QueryingServerHelper extends QueryingServerHelperBase<QueryingServe
 		return getResourceByIdResponse(resourceType, resourceId).getResult();
 	}
 
+	@Override 
+	public FhirResponse<IBaseResource> fetchServer(final String resourceType, String resourceQuery) {
+		FhirClientWrapper client = clients.next();
+		FhirResponse<IBaseResource> resource = null;
+		log.debug("Fetching {} {} resource using client for version {} ", client.getFhirContext().getVersion().getVersion().name(),
+				resourceType,  client.getFhirContext().getVersion().getVersion().name());
+		resource = runWithInterceptors(new QueryingCallback<IBaseResource>() {
+			@Override
+			@SuppressWarnings("unchecked")
+			public IBaseResource execute(FhirClientWrapper client) {
+				log.debug("Invoking url {}", resourceQuery);
+				try {
+					Class<IBaseResource> clz = (Class<IBaseResource>) Class.forName("org.hl7.fhir.dstu3.model." + resourceType);
+					return client.fetchResourceFromUrl(clz, resourceQuery);
+				} catch (ClassNotFoundException e) {
+					log.error("ResourceType " + resourceType + " not supported for direct path reading in fhir " + client.getFhirContext().getVersion().getVersion().name());
+					return null;
+				}
+			}
+		}, client);
+		if (resource == null) {
+			return new FhirResponse<>(null, 404, "Not Found");
+		}
+		return resource;
+	}
+	
 	@Override
 	public FhirResponse<List<IBaseResource>> queryServer(String resourceQuery) {
 		FhirClientWrapper client = clients.next();

--- a/fhir-query-helper-r4/pom.xml
+++ b/fhir-query-helper-r4/pom.xml
@@ -26,7 +26,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-r4</artifactId>
-	<version>0.0.5</version>
+	<version>0.0.6</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper R4</description>
 

--- a/fhir-query-helper-r4/src/test/java/io/elimu/a2d2/cds/fhir/helper/test/FhirTest.java
+++ b/fhir-query-helper-r4/src/test/java/io/elimu/a2d2/cds/fhir/helper/test/FhirTest.java
@@ -1,0 +1,31 @@
+package io.elimu.a2d2.cds.fhir.helper.test;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+import io.elimu.a2d2.cds.fhir.helper.FhirResponse;
+import io.elimu.a2d2.cds.fhir.helper.r4.QueryingServerHelper;
+
+public class FhirTest {
+
+	@Test
+	public void testFhirGetByPath() {
+		Assume.assumeTrue(System.getProperty("fhirapikey") != null && System.getProperty("fhirurl") != null && System.getProperty("fhirpatientid") != null);
+		String url = System.getProperty("fhirurl");
+		String apikey = System.getProperty("fhirapikey");
+		String patientId = System.getProperty("fhirpatientid");
+		QueryingServerHelper helper = new QueryingServerHelper(url);
+		helper.addHeader("x-api-key", apikey);
+		FhirResponse<IBaseResource> resp1 = helper.getResourceByIdInPathResponse("Patient", patientId);
+		Assert.assertNotNull(resp1);
+		Assert.assertNotNull(resp1.getResult());
+		Assert.assertEquals(200, resp1.getResponseStatusCode());
+		
+		FhirResponse<IBaseResource> resp2 = helper.getResourceByIdInPathResponse("Patient", patientId + System.currentTimeMillis());
+		Assert.assertNotNull(resp2);
+		Assert.assertNull(resp2.getResult());
+		Assert.assertEquals(404, resp2.getResponseStatusCode());
+	}
+}

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -19,6 +19,12 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-structures-r4</artifactId>
+			<version>3.8.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>cds-hook-model</artifactId>
 		</dependency>
@@ -301,16 +307,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-    					<artifactId>slf4j-api</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 			<exclusions>
 				<exclusion>
@@ -328,6 +324,10 @@
 				<exclusion>
 					<groupId>com.fasterxml.jackson.core</groupId>
 					<artifactId>jackson-annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+    					<artifactId>slf4j-api</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/kie-based-services/src/main/java/io/elimu/genericapi/plugins/PKeyLoaderPluginLoader.java
+++ b/kie-based-services/src/main/java/io/elimu/genericapi/plugins/PKeyLoaderPluginLoader.java
@@ -1,0 +1,9 @@
+package io.elimu.genericapi.plugins;
+
+public class PKeyLoaderPluginLoader extends TemplatePluginLoader implements ModulePluginLoader {
+
+	public PKeyLoaderPluginLoader() {
+		super("pkcs");
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<jackson.version>2.9.10.5</jackson.version>
 		<mockito.version>2.8.9</mockito.version>
 		<jedis.version>3.2.0</jedis.version>
-		<cds.helper.version>0.0.5</cds.helper.version>
+		<cds.helper.version>0.0.6</cds.helper.version>
 		<freemarker.version>2.3.30</freemarker.version>
 		<jacoco.version>0.8.3</jacoco.version>
 	</properties>


### PR DESCRIPTION
Allows us to build a JWT token, do direct path fetches for FHIR queries, and adds a new status controller to replace the actuator reference to something related to our internal status