### PR TITLE
Added initializer so that we can use default, cross-service variables

### DIFF
--- a/kie-based-services/src/main/java/io/elimu/serviceapi/service/ProcessVariableInitHelper.java
+++ b/kie-based-services/src/main/java/io/elimu/serviceapi/service/ProcessVariableInitHelper.java
@@ -28,8 +28,16 @@ public class ProcessVariableInitHelper {
 			String envPrefix = System.getProperty("proc.envvar.prefix");
 			if (envPrefix != null) {
 				String prefix = envPrefix.toLowerCase() + "." + dep.getArtifactId().toLowerCase();
+				String defaultPrefix = envPrefix.toLowerCase() + ".allservices";
 				String keySet = System.getProperties().keySet().toString();
 				log.trace("System properties available for loading are {}", keySet);
+				System.getProperties().keySet().stream().
+					filter(k -> k.toString().toLowerCase().startsWith(defaultPrefix)).
+					forEach(k -> setServiceProperty(
+						serviceProperty,
+						k.toString().substring(defaultPrefix.length() + 1),
+						System.getProperty(k.toString())
+					));
 				System.getProperties().keySet().stream().
 					filter(k -> k.toString().toLowerCase().startsWith(prefix)).
 					forEach(k -> setServiceProperty(

--- a/kie-based-services/src/test/java/io/elimu/serviceapi/service/ProcessVariableInitHelperTest.java
+++ b/kie-based-services/src/test/java/io/elimu/serviceapi/service/ProcessVariableInitHelperTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Map;
 import java.util.Properties;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
@@ -15,7 +16,9 @@ import java.util.jar.Manifest;
 import org.drools.core.io.impl.BaseResource;
 import org.drools.core.io.impl.ByteArrayResource;
 import org.drools.core.io.impl.ClassPathResource;
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Test;
 import org.kie.api.KieServices;
 import org.mockito.InjectMocks;
 
@@ -119,5 +122,15 @@ public class ProcessVariableInitHelperTest {
 			target.close();
 		}
 
-
+		@Test
+		public void testNewPropertiesForAllProcesses() {
+			AppContextUtils.getInstance().testSetEnvironmentName("dev");
+			Dependency dep = new Dependency(System.getProperty("test.service.release") + ".test4");
+			System.setProperty("proc.envvar.prefix", "a2d2test");
+			System.setProperty("a2d2test.allservices.sid", "mynewsid");
+			Map<String, Object> variables = pvh.initVariables(dep);
+			Assert.assertNotNull(variables);
+			Assert.assertNotNull(variables.get("sid"));
+			Assert.assertEquals("mynewsid", variables.get("sid"));
+		}
 }


### PR DESCRIPTION
We already had the chance of doing this with JVM properties:

-Dproc.envvar.prefix=a2d2 -Da2d2.service-1.variable-a=123 -Da2d2.service-2.variable-a=123 -Da2d2.service-3.variable-a=123

The purpose of this pull request is to be able to have JVM variables like this:

-Dproc.envvar.prefix=a2d2 -Da2d2.**allservices**.variable-a=123

That would work for all services (service-1, service-2, etc)

If in the future we need to have a different value for one specific service, this is also possible:

-Dproc.envvar.prefix=a2d2 -Da2d2.allservices.variable-a=123 -Da2d2.special-service.variable-a=456

Where all services will have variable-a preinitialized with 123, except special-service, which will use 456
