### PR TITLE
OAuthHelper for simpler OAuth management

### DIFF
--- a/oauth-helpers/pom.xml
+++ b/oauth-helpers/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2018-2020 Elimu Informatics
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http:  www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>io.elimu.a2d2</groupId>
+		<artifactId>parent</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>oauth-helpers</artifactId>
+	<version>0.0.6</version>
+	<description>OAuth Helper</description>
+
+	<properties>
+		<genericmodel.version>0.0.1-SNAPSHOT</genericmodel.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>io.elimu.a2d2</groupId>
+			<artifactId>fhir-query-helper-base</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.elimu.a2d2</groupId>
+			<artifactId>cds-hook-model</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.elimu.a2d2</groupId>
+			<artifactId>generic-model</artifactId>
+			<version>${genericmodel.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.kie</groupId>
+			<artifactId>kie-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.drools</groupId>
+			<artifactId>drools-compiler</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.mvel</groupId>
+					<artifactId>mvel2</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-codec</groupId>
+					<artifactId>commons-codec</artifactId>
+				</exclusion>
+			</exclusions>
+			<scope>test</scope>
+		</dependency>
+    		<dependency>
+			<groupId>org.mvel</groupId>
+			<artifactId>mvel2</artifactId>
+			<version>2.4.4.Final</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-structures-r4</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/oauth-helpers/src/main/java/io/elimu/a2d2/NDOFilter.java
+++ b/oauth-helpers/src/main/java/io/elimu/a2d2/NDOFilter.java
@@ -1,0 +1,38 @@
+// Copyright 2018-2021 Elimu Informatics
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.elimu.a2d2;
+
+import org.kie.api.runtime.ObjectFilter;
+
+import io.elimu.a2d2.genericmodel.NamedDataObject;
+
+public class NDOFilter implements ObjectFilter {
+
+	private final String filterName;
+
+	public NDOFilter(String filter) {
+		this.filterName = filter;
+	}
+	
+	@Override
+	public boolean accept(Object object) {
+		if (NamedDataObject.class.isAssignableFrom(object.getClass())) {
+			NamedDataObject ndo = (NamedDataObject) object;
+			return filterName.equals(ndo.getName());
+		}
+		return false;
+	}
+
+}

--- a/oauth-helpers/src/main/java/io/elimu/a2d2/OAuthHelper.java
+++ b/oauth-helpers/src/main/java/io/elimu/a2d2/OAuthHelper.java
@@ -1,0 +1,157 @@
+// Copyright 2018-2021 Elimu Informatics
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.elimu.a2d2;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.kie.api.runtime.rule.RuleContext;
+
+import io.elimu.a2d2.cds.fhir.helper.QueryingServerHelperBase;
+import io.elimu.a2d2.genericmodel.NamedDataObject;
+import io.elimu.a2d2.oauth.BodyBuilder;
+import io.elimu.a2d2.oauth.OAuthUtils;
+
+public class OAuthHelper {
+
+	public static String getOAuthToken(RuleContext context) throws IllegalAccessException {
+		return getOAuthToken(context, "fhirScope", "fhirTokenUrl", "fhirClientId", "fhirClientSecret", "fhirPassword", "fhirUsername", "fhirGrantType");
+	}
+	
+	public static String getOAuthToken(RuleContext context, 
+			String scopeKey, String tokenUrlKey, String clientIdKey, String clientSecretKey, 
+			String passwordKey, String usernameKey, String grantTypeKey) throws IllegalAccessException {
+		BodyBuilder builder = new BodyBuilder();
+		String scope = extractParameter(context, scopeKey);
+		if (scope != null) {
+			builder.addToBody("scope", scope);
+		}
+		
+		String tokenUrl = extractParameter(context, tokenUrlKey);
+		if (tokenUrl != null) {
+			builder.addToBody("token_url", tokenUrl);
+		}
+		
+		String clientId = extractParameter(context, clientIdKey);
+		if (clientId != null) {
+			builder.addToBody("client_id", clientId);
+		}
+
+		String clientSecret = extractParameter(context, clientSecretKey);
+		if (clientSecret != null) {
+			builder.addToBody("client_secret", clientSecret);
+		}
+
+		String password = extractParameter(context, passwordKey + "Decrypt");
+		if (password != null) {
+			builder.addToBody("password", password);
+		} else {
+			password = extractParameter(context, passwordKey);
+			if (password != null) {
+				builder.addToBody("password", password);
+			}
+		}
+		
+		String username = extractParameter(context, usernameKey);
+		if (username != null) {
+			builder.addToBody("username", username);
+		}
+		
+		String grantType = extractParameter(context, grantTypeKey);
+		if (grantType != null) {
+			builder.addToBody("grant_type", grantType);
+		}
+		
+		String token = null;
+		String body = builder.build();
+		Map<String, Object> results = OAuthUtils.authenticate(body, tokenUrl, clientId, clientSecret);
+		token = (String) results.get("access_token");
+		if (token == null) {
+			throw new IllegalAccessException((String) results.get("errorMessage"));
+		}
+		return token;
+	}
+	
+	public static <T> T addOAuthToken(RuleContext context, QueryingServerHelperBase<T, IBaseResource> qsh) throws IllegalAccessException {
+		return addOAuthToken(context, qsh, "fhirScope", "fhirTokenUrl", "fhirClientId", "fhirClientSecret", "fhirPassword", "fhirUsername", "fhirGrantType");
+	}
+	
+	public static <T> T addOAuthToken(RuleContext context, QueryingServerHelperBase<T, IBaseResource> qsh,
+			String scopeKey, String tokenUrlKey, String clientIdKey, String clientSecretKey, 
+			String passwordKey, String usernameKey, String grantTypeKey) throws IllegalAccessException {
+		List<String> params = new LinkedList<>();
+		String scope = extractParameter(context, scopeKey);
+		if (scope != null) {
+			params.add("scope");
+			params.add(scope);
+		}
+		
+		String tokenUrl = extractParameter(context, tokenUrlKey);
+		if (tokenUrl != null) {
+			params.add("token_url");
+			params.add(tokenUrl);
+		}
+		
+		String clientId = extractParameter(context, clientIdKey);
+		if (clientId != null) {
+			params.add("client_id");
+			params.add(clientId);
+		}
+
+		String clientSecret = extractParameter(context, clientSecretKey);
+		if (clientSecret != null) {
+			params.add("client_secret");
+			params.add(clientSecret);
+		}
+
+		String password = extractParameter(context, passwordKey + "Decrypt");
+		if (password != null) {
+			params.add("password");
+			params.add(password);
+		} else {
+			password = extractParameter(context, passwordKey);
+			if (password != null) {
+				params.add("password");
+				params.add(password);
+			}
+		}
+		
+		String username = extractParameter(context, usernameKey);
+		if (username != null) {
+			params.add("username");
+			params.add(username);
+		}
+		
+		String grantType = extractParameter(context, grantTypeKey);
+		if (grantType != null) {
+			params.add("grant_type");
+			params.add(grantType);
+		}
+		
+		return qsh.addAuthentication(QueryingServerHelperBase.OAUTH, params.toArray(new String[params.size()]));
+	}
+
+	private static String extractParameter(RuleContext context, String paramName) throws IllegalAccessException {
+		Collection<?> objects = context.getKieRuntime().getObjects(new NDOFilter(paramName));
+		if (objects.isEmpty()) {
+			return null;
+		}
+		NamedDataObject retval = (NamedDataObject) objects.iterator().next();
+		return (String) retval.getValue();
+	}
+}

--- a/oauth-helpers/src/test/java/io/elimu/a2d2/OAuthHelperTest.java
+++ b/oauth-helpers/src/test/java/io/elimu/a2d2/OAuthHelperTest.java
@@ -1,0 +1,144 @@
+// Copyright 2018-2021 Elimu Informatics
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.elimu.a2d2;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Resource;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.Message;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieSession;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
+import ca.uhn.fhir.rest.client.api.IClientInterceptor;
+import ca.uhn.fhir.rest.client.interceptor.BearerTokenAuthInterceptor;
+import io.elimu.a2d2.cds.fhir.helper.FhirResponse;
+import io.elimu.a2d2.cds.fhir.helper.QueryingServerHelperBase;
+import io.elimu.a2d2.cds.fhir.helper.QueryingServerHelperBase.FhirVersionAbs;
+import io.elimu.a2d2.genericmodel.NamedDataObject;
+
+public class OAuthHelperTest {
+	
+	private KieSession ksession;
+
+	@Before
+	public void setUp() throws Exception {
+		Assume.assumeTrue(System.getProperty("tokenUrl") != null && System.getProperty("oauthUsername") != null && System.getProperty("oauthPassword") != null);
+		
+		KieServices ks = KieServices.get();
+		KieFileSystem kfs = ks.newKieFileSystem();
+		String drl = "import io.elimu.a2d2.cds.fhir.helper.QueryingServerHelperBase;\n"
+				+ "import io.elimu.a2d2.genericmodel.NamedDataObject;\n"
+				+ "import io.elimu.a2d2.OAuthHelper;\n"
+				+ "\n"
+				+ "rule \"test\" \n"
+				+ "salience 10\n"
+				+ "when\n"
+				+ "	qsh: QueryingServerHelperBase()\n"
+				+ "	NamedDataObject(name == \"fhirScope\")\n"
+				+ "then\n"
+				+ "	OAuthHelper.addOAuthToken(drools, qsh);\n"
+				+ "end\n"
+				+ "";
+		
+		kfs.write("src/main/resources/rules.drl", ks.getResources().newByteArrayResource(drl.getBytes()));
+		KieBuilder kbuilder = ks.newKieBuilder(kfs);
+		kbuilder.buildAll();
+		if (kbuilder.getResults().hasMessages(Message.Level.ERROR)) {
+			throw new IllegalArgumentException("Cannot compile kbase: " + kbuilder.getResults());
+		}
+		
+		KieContainer kc = ks.newKieContainer(kbuilder.getKieModule().getReleaseId());
+		this.ksession = kc.newKieSession();
+	}
+	
+	@After
+	public void tearDown() throws Exception {
+		if (ksession != null) {
+			ksession.destroy();
+		}
+	}
+	
+	@Test
+	public void testGetToken() throws Exception {
+		TestQueryingServerHelper qsh = new TestQueryingServerHelper();
+		this.ksession.insert(qsh);
+		this.ksession.insert(new NamedDataObject("fhirScope", "offline_access"));
+		this.ksession.insert(new NamedDataObject("fhirClientId", "omnibus-api"));
+		this.ksession.insert(new NamedDataObject("fhirClientSecret", ""));
+		this.ksession.insert(new NamedDataObject("fhirGrantType", "password"));
+		this.ksession.insert(new NamedDataObject("fhirTokenUrl", System.getProperty("tokenUrl")));
+		this.ksession.insert(new NamedDataObject("fhirUsername", System.getProperty("oauthUsername")));
+		this.ksession.insert(new NamedDataObject("fhirPasswordDecrypt", System.getProperty("oauthPassword")));
+		
+		this.ksession.fireAllRules();
+		String token = qsh.getToken();
+		Assert.assertNotNull(token);
+		Assert.assertNotEquals("null", token);
+	}
+	
+	public static enum FhirVersion implements FhirVersionAbs {
+		
+		FHIR4(FhirContext.forR4());
+		
+		private final FhirContext ctx;
+
+		FhirVersion(FhirContext ctx) {
+			this.ctx = ctx;
+		}
+
+		public FhirContext getCtx() {
+			return ctx;
+		}
+	}
+	
+	private static class TestQueryingServerHelper extends QueryingServerHelperBase<Resource, IBaseResource> {
+		
+		public TestQueryingServerHelper() {
+			super("https://fhir4-internal.elimuinformatics.com/fhir", FhirVersion.FHIR4, FhirVersionEnum.R4);
+		}
+
+		@Override
+		public FhirResponse<IBaseResource> fetchServer(String resourceType, String resourceQuery) {
+			return new FhirResponse<IBaseResource>(null, 404, "Not Found");
+		}
+		
+		@Override
+		public FhirResponse<List<IBaseResource>> queryServer(String resourceQuery) {
+			return new FhirResponse<List<IBaseResource>>(new ArrayList<IBaseResource>(), 200, "OK");
+		}
+
+		public String getToken() throws Exception {
+			for (IClientInterceptor interceptor : super.interceptors) {
+				if (interceptor instanceof BearerTokenAuthInterceptor) {
+					BearerTokenAuthInterceptor btai = (BearerTokenAuthInterceptor) interceptor;
+					return btai.getToken();
+				}
+			}
+			return null;
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
 		<module>fhir-query-helper-dstu2</module>
 		<module>fhir-query-helper-dstu3</module>
 		<module>fhir-query-helper-r4</module>
+		<module>oauth-helpers</module>
 		<module>fhir-helpers</module>
 		<module>task-utilities</module>
 		<module>sms-wih</module>


### PR DESCRIPTION
The purpose of this PR is to create an even simpler OAuth helper, that just will search the variables for you. In this helper, assuming you have predefined variables for OAuth token obtaining, you can simply do this call in the rules:

`import io.elimu.a2d2.cds.fhir.helper.r4.QueryingServerHelper;
import io.elimu.a2d2.genericmodel.NamedDataObject;
import io.elimu.a2d2.OAuthHelper;

rule "test" 
salience 10
when
     qsh: QueryingServerHelper()
     NamedDataObject(name == "fhirScope")
then
     OAuthHelper.addOAuthToken(drools, qsh);
end`

Similarly, you could do this:

`import io.elimu.a2d2.cds.fhir.helper.r4.QueryingServerHelper;
import io.elimu.a2d2.genericmodel.NamedDataObject;
import io.elimu.a2d2.OAuthHelper;

rule "test" 
salience 10
when
     qsh: QueryingServerHelper()
     NamedDataObject(name == "fhirScope")
then
     qsh.addHeader("Authorization", "Bearer " + OAuthHelper.getOAuthToken(drools));
end`
