### PR TITLE
logger for outputting rule and process exeutions in the response

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ You will need to install the following:
 
     Then, from Eclipse, click on debug -> Run as -> Remote Java Application -> new, and connect using localhost port 8000
 
+    Also, if you want to debug the rule and process execution of a particular request, add the HTTP header X-Enable-Debug: true to the request for enabling it on the server logs, or X-Output-Debug: true to enable it on the HTTP output 
 
 ### Deploying with Docker 
 

--- a/cds-hook-services/src/main/java/io/elimu/cdshookapi/service/ServiceHelper.java
+++ b/cds-hook-services/src/main/java/io/elimu/cdshookapi/service/ServiceHelper.java
@@ -92,7 +92,13 @@ public class ServiceHelper {
 			executor.execute(() -> {
 				// we now have two types of services: generic services and kie services
 				// then we start every one
+				Iterable<ServiceInfo> allServices = cdsRepo.findAllGeneric();
+				log.info("Starting all services");
+				int index = 1;
+				int count = cdsRepo.countAllGeneric();
 				for (ServiceInfo info : cdsRepo.findAllGeneric()) {
+					log.info("Starting service " + index + " out of " + count);
+					index++;
 					initializeKieService(info.getServiceData(), info.getDefaultCustomer());
 				}
 				RunningServices.getInstance().markStarted();

--- a/kie-based-services/src/main/java/io/elimu/genericapi/service/GenericDebugListener.java
+++ b/kie-based-services/src/main/java/io/elimu/genericapi/service/GenericDebugListener.java
@@ -24,133 +24,294 @@ import org.kie.api.runtime.KieSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
 public class GenericDebugListener implements ProcessEventListener, RuleRuntimeEventListener, AgendaEventListener {
 
 	private final Logger logger;
+	private final boolean sendToLogs;	
+	private JsonArray events = new JsonArray();
 	
-	public GenericDebugListener(String serviceId, KieSession ksession) {
+	public GenericDebugListener(String serviceId, KieSession ksession, boolean sendToLogs) {
 		ksession.addEventListener((ProcessEventListener) this);
 		ksession.addEventListener((RuleRuntimeEventListener) this);
 		ksession.addEventListener((AgendaEventListener) this);
+		this.sendToLogs = sendToLogs;
 		this.logger = LoggerFactory.getLogger("io.elimu.a2d2."+serviceId);
 	}
 
 	private void log(KieRuntimeEvent event) {
-		logger.info(event.toString());
+		if (this.sendToLogs) {
+			logger.info(event.toString());
+		}
 	}
 	
 	@Override
 	public void matchCreated(MatchCreatedEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("matchCreated"));
+		evt.add("ruleName", new JsonPrimitive(event.getMatch().getRule().getName()));
+		JsonArray array = new JsonArray();
+		for (Object obj : event.getMatch().getObjects()) {
+			array.add(obj.toString());
+		}
+		evt.add("objects", array);
+		events.add(evt);
 	}
 
 	@Override
 	public void matchCancelled(MatchCancelledEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("matchCancelled"));
+		evt.add("cause", new JsonPrimitive(event.getCause().toString()));
+		evt.add("ruleName", new JsonPrimitive(event.getMatch().getRule().getName()));
+		JsonArray array = new JsonArray();
+		for (Object obj : event.getMatch().getObjects()) {
+			array.add(obj.toString());
+		}
+		evt.add("objects", array);
+		events.add(evt);
 	}
 
 	@Override
 	public void beforeMatchFired(BeforeMatchFiredEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("beforeMatchFired"));
+		evt.add("ruleName", new JsonPrimitive(event.getMatch().getRule().getName()));
+		JsonArray array = new JsonArray();
+		for (Object obj : event.getMatch().getObjects()) {
+			array.add(obj.toString());
+		}
+		evt.add("objects", array);
+		events.add(evt);
 	}
 
 	@Override
 	public void afterMatchFired(AfterMatchFiredEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("afterMatchFired"));
+		evt.add("ruleName", new JsonPrimitive(event.getMatch().getRule().getName()));
+		JsonArray array = new JsonArray();
+		for (Object obj : event.getMatch().getObjects()) {
+			array.add(obj.toString());
+		}
+		evt.add("objects", array);
+		events.add(evt);
 	}
 
 	@Override
 	public void agendaGroupPopped(AgendaGroupPoppedEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("agendaGroupPopped"));
+		evt.add("agendaGroup", new JsonPrimitive(event.getAgendaGroup().getName()));
+		events.add(evt);
 	}
 
 	@Override
 	public void agendaGroupPushed(AgendaGroupPushedEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("agendaGroupPushed"));
+		evt.add("agendaGroup", new JsonPrimitive(event.getAgendaGroup().getName()));
+		events.add(evt);
 	}
 
 	@Override
 	public void beforeRuleFlowGroupActivated(RuleFlowGroupActivatedEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("beforeRuleFlowGroupActivated"));
+		evt.add("ruleFlowGroup", new JsonPrimitive(event.getRuleFlowGroup().getName()));
+		events.add(evt);
 	}
 
 	@Override
 	public void afterRuleFlowGroupActivated(RuleFlowGroupActivatedEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("afterRuleFlowGroupActivated"));
+		evt.add("ruleFlowGroup", new JsonPrimitive(event.getRuleFlowGroup().getName()));
+		events.add(evt);
 	}
 
 	@Override
 	public void beforeRuleFlowGroupDeactivated(RuleFlowGroupDeactivatedEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("beforeRuleFlowGroupDeactivated"));
+		evt.add("ruleFlowGroup", new JsonPrimitive(event.getRuleFlowGroup().getName()));
+		events.add(evt);
 	}
 
 	@Override
 	public void afterRuleFlowGroupDeactivated(RuleFlowGroupDeactivatedEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("afterRuleFlowGroupDeactivated"));
+		evt.add("ruleFlowGroup", new JsonPrimitive(event.getRuleFlowGroup().getName()));
+		events.add(evt);
 	}
 
 	@Override
 	public void objectInserted(ObjectInsertedEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("objectInserted"));
+		if (event.getRule() != null) {
+			evt.add("ruleName", new JsonPrimitive(event.getRule().getName()));
+		}
+		evt.add("object", new JsonPrimitive(event.getObject().toString()));
+		events.add(evt);
 	}
 
 	@Override
 	public void objectUpdated(ObjectUpdatedEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("objectUpdated"));
+		if (event.getRule() != null) {
+			evt.add("ruleName", new JsonPrimitive(event.getRule().getName()));
+		}
+		evt.add("object", new JsonPrimitive(event.getObject().toString()));
+		events.add(evt);
 	}
 
 	@Override
 	public void objectDeleted(ObjectDeletedEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("objectDeleted"));
+		if (event.getRule() != null) {
+			evt.add("ruleName", new JsonPrimitive(event.getRule().getName()));
+		}
+		evt.add("object", new JsonPrimitive(event.getOldObject().toString()));
+		events.add(evt);
 	}
 
 	@Override
 	public void beforeProcessStarted(ProcessStartedEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("beforeProcessStarted"));
+		evt.add("processId", new JsonPrimitive(event.getProcessInstance().getProcessId()));
+		evt.add("processInstanceId", new JsonPrimitive(event.getProcessInstance().getId()));
+		events.add(evt);
 	}
 
 	@Override
 	public void afterProcessStarted(ProcessStartedEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("afterProcessStarted"));
+		evt.add("processId", new JsonPrimitive(event.getProcessInstance().getProcessId()));
+		evt.add("processInstanceId", new JsonPrimitive(event.getProcessInstance().getId()));
+		events.add(evt);
 	}
 
 	@Override
 	public void beforeProcessCompleted(ProcessCompletedEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("beforeProcessCompleted"));
+		evt.add("processId", new JsonPrimitive(event.getProcessInstance().getProcessId()));
+		evt.add("processInstanceId", new JsonPrimitive(event.getProcessInstance().getId()));
+		events.add(evt);
 	}
 
 	@Override
 	public void afterProcessCompleted(ProcessCompletedEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("afterProcessCompleted"));
+		evt.add("processId", new JsonPrimitive(event.getProcessInstance().getProcessId()));
+		evt.add("processInstanceId", new JsonPrimitive(event.getProcessInstance().getId()));
+		events.add(evt);
 	}
 
 	@Override
 	public void beforeNodeTriggered(ProcessNodeTriggeredEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("beforeNodeTriggered"));
+		evt.add("processId", new JsonPrimitive(event.getProcessInstance().getProcessId()));
+		evt.add("processInstanceId", new JsonPrimitive(event.getProcessInstance().getId()));
+		evt.add("nodeName", new JsonPrimitive(event.getNodeInstance().getNodeName()));
+		events.add(evt);
 	}
 
 	@Override
 	public void afterNodeTriggered(ProcessNodeTriggeredEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("afterNodeTriggered"));
+		evt.add("processId", new JsonPrimitive(event.getProcessInstance().getProcessId()));
+		evt.add("processInstanceId", new JsonPrimitive(event.getProcessInstance().getId()));
+		evt.add("nodeName", new JsonPrimitive(event.getNodeInstance().getNodeName()));
+		events.add(evt);
 	}
 
 	@Override
 	public void beforeNodeLeft(ProcessNodeLeftEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("beforeNodeLeft"));
+		evt.add("processId", new JsonPrimitive(event.getProcessInstance().getProcessId()));
+		evt.add("processInstanceId", new JsonPrimitive(event.getProcessInstance().getId()));
+		evt.add("nodeName", new JsonPrimitive(event.getNodeInstance().getNodeName()));
+		events.add(evt);
 	}
 
 	@Override
 	public void afterNodeLeft(ProcessNodeLeftEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("afterNodeLeft"));
+		evt.add("processId", new JsonPrimitive(event.getProcessInstance().getProcessId()));
+		evt.add("processInstanceId", new JsonPrimitive(event.getProcessInstance().getId()));
+		evt.add("nodeName", new JsonPrimitive(event.getNodeInstance().getNodeName()));
+		events.add(evt);
 	}
 
 	@Override
 	public void beforeVariableChanged(ProcessVariableChangedEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("beforeVariableChanged"));
+		evt.add("processId", new JsonPrimitive(event.getProcessInstance().getProcessId()));
+		evt.add("processInstanceId", new JsonPrimitive(event.getProcessInstance().getId()));
+		evt.add("variableId", new JsonPrimitive(event.getVariableId()));
+		evt.add("oldValue", event.getOldValue() == null ? JsonNull.INSTANCE : new JsonPrimitive(event.getOldValue().toString()));
+		evt.add("newValue", event.getNewValue() == null ? JsonNull.INSTANCE : new JsonPrimitive(event.getNewValue().toString()));
+		events.add(evt);
 	}
 
 	@Override
 	public void afterVariableChanged(ProcessVariableChangedEvent event) {
 		log(event);
+		JsonObject evt = new JsonObject();
+		evt.add("eventType", new JsonPrimitive("afterVariableChanged"));
+		evt.add("processId", new JsonPrimitive(event.getProcessInstance().getProcessId()));
+		evt.add("processInstanceId", new JsonPrimitive(event.getProcessInstance().getId()));
+		evt.add("variableId", new JsonPrimitive(event.getVariableId()));
+		evt.add("oldValue", event.getOldValue() == null ? JsonNull.INSTANCE : new JsonPrimitive(event.getOldValue().toString()));
+		evt.add("newValue", event.getNewValue() == null ? JsonNull.INSTANCE : new JsonPrimitive(event.getNewValue().toString()));
+		events.add(evt);
 	}
+
+	public String toJson(String originalBody) {
+		JsonObject retval = new JsonObject();
+		retval.add("result", new JsonPrimitive(originalBody));
+		retval.add("debug", events);
+		return new Gson().toJson(retval);
+	}
+	
 }

--- a/kie-based-services/src/main/java/io/elimu/genericapi/service/GenericDebugListener.java
+++ b/kie-based-services/src/main/java/io/elimu/genericapi/service/GenericDebugListener.java
@@ -1,5 +1,7 @@
 package io.elimu.genericapi.service;
 
+import java.util.regex.Pattern;
+
 import org.kie.api.event.KieRuntimeEvent;
 import org.kie.api.event.process.ProcessCompletedEvent;
 import org.kie.api.event.process.ProcessEventListener;
@@ -58,7 +60,7 @@ public class GenericDebugListener implements ProcessEventListener, RuleRuntimeEv
 		evt.add("ruleName", new JsonPrimitive(event.getMatch().getRule().getName()));
 		JsonArray array = new JsonArray();
 		for (Object obj : event.getMatch().getObjects()) {
-			array.add(obj.toString());
+			array.add(hidePasswordValue(obj));
 		}
 		evt.add("objects", array);
 		events.add(evt);
@@ -73,7 +75,7 @@ public class GenericDebugListener implements ProcessEventListener, RuleRuntimeEv
 		evt.add("ruleName", new JsonPrimitive(event.getMatch().getRule().getName()));
 		JsonArray array = new JsonArray();
 		for (Object obj : event.getMatch().getObjects()) {
-			array.add(obj.toString());
+			array.add(hidePasswordValue(obj));
 		}
 		evt.add("objects", array);
 		events.add(evt);
@@ -87,7 +89,7 @@ public class GenericDebugListener implements ProcessEventListener, RuleRuntimeEv
 		evt.add("ruleName", new JsonPrimitive(event.getMatch().getRule().getName()));
 		JsonArray array = new JsonArray();
 		for (Object obj : event.getMatch().getObjects()) {
-			array.add(obj.toString());
+			array.add(hidePasswordValue(obj));
 		}
 		evt.add("objects", array);
 		events.add(evt);
@@ -101,7 +103,7 @@ public class GenericDebugListener implements ProcessEventListener, RuleRuntimeEv
 		evt.add("ruleName", new JsonPrimitive(event.getMatch().getRule().getName()));
 		JsonArray array = new JsonArray();
 		for (Object obj : event.getMatch().getObjects()) {
-			array.add(obj.toString());
+			array.add(hidePasswordValue(obj));
 		}
 		evt.add("objects", array);
 		events.add(evt);
@@ -169,7 +171,7 @@ public class GenericDebugListener implements ProcessEventListener, RuleRuntimeEv
 		if (event.getRule() != null) {
 			evt.add("ruleName", new JsonPrimitive(event.getRule().getName()));
 		}
-		evt.add("object", new JsonPrimitive(event.getObject().toString()));
+		evt.add("object", new JsonPrimitive(hidePasswordValue(event.getObject())));
 		events.add(evt);
 	}
 
@@ -181,7 +183,7 @@ public class GenericDebugListener implements ProcessEventListener, RuleRuntimeEv
 		if (event.getRule() != null) {
 			evt.add("ruleName", new JsonPrimitive(event.getRule().getName()));
 		}
-		evt.add("object", new JsonPrimitive(event.getObject().toString()));
+		evt.add("object", new JsonPrimitive(hidePasswordValue(event.getObject())));
 		events.add(evt);
 	}
 
@@ -193,7 +195,7 @@ public class GenericDebugListener implements ProcessEventListener, RuleRuntimeEv
 		if (event.getRule() != null) {
 			evt.add("ruleName", new JsonPrimitive(event.getRule().getName()));
 		}
-		evt.add("object", new JsonPrimitive(event.getOldObject().toString()));
+		evt.add("object", new JsonPrimitive(hidePasswordValue(event.getOldObject())));
 		events.add(evt);
 	}
 
@@ -289,8 +291,13 @@ public class GenericDebugListener implements ProcessEventListener, RuleRuntimeEv
 		evt.add("processId", new JsonPrimitive(event.getProcessInstance().getProcessId()));
 		evt.add("processInstanceId", new JsonPrimitive(event.getProcessInstance().getId()));
 		evt.add("variableId", new JsonPrimitive(event.getVariableId()));
-		evt.add("oldValue", event.getOldValue() == null ? JsonNull.INSTANCE : new JsonPrimitive(event.getOldValue().toString()));
-		evt.add("newValue", event.getNewValue() == null ? JsonNull.INSTANCE : new JsonPrimitive(event.getNewValue().toString()));
+		if (event.getVariableId().toLowerCase().contains("password")) {
+			evt.add("oldValue", event.getOldValue() == null ? JsonNull.INSTANCE : new JsonPrimitive("*******"));
+			evt.add("newValue", event.getNewValue() == null ? JsonNull.INSTANCE : new JsonPrimitive("*******"));
+		} else {
+			evt.add("oldValue", event.getOldValue() == null ? JsonNull.INSTANCE : new JsonPrimitive(hidePasswordValue(event.getOldValue())));
+			evt.add("newValue", event.getNewValue() == null ? JsonNull.INSTANCE : new JsonPrimitive(hidePasswordValue(event.getNewValue())));
+		}
 		events.add(evt);
 	}
 
@@ -302,8 +309,13 @@ public class GenericDebugListener implements ProcessEventListener, RuleRuntimeEv
 		evt.add("processId", new JsonPrimitive(event.getProcessInstance().getProcessId()));
 		evt.add("processInstanceId", new JsonPrimitive(event.getProcessInstance().getId()));
 		evt.add("variableId", new JsonPrimitive(event.getVariableId()));
-		evt.add("oldValue", event.getOldValue() == null ? JsonNull.INSTANCE : new JsonPrimitive(event.getOldValue().toString()));
-		evt.add("newValue", event.getNewValue() == null ? JsonNull.INSTANCE : new JsonPrimitive(event.getNewValue().toString()));
+		if (event.getVariableId().toLowerCase().contains("password")) {
+			evt.add("oldValue", event.getOldValue() == null ? JsonNull.INSTANCE : new JsonPrimitive("*******"));
+			evt.add("newValue", event.getNewValue() == null ? JsonNull.INSTANCE : new JsonPrimitive("*******"));
+		} else {
+			evt.add("oldValue", event.getOldValue() == null ? JsonNull.INSTANCE : new JsonPrimitive(hidePasswordValue(event.getOldValue())));
+			evt.add("newValue", event.getNewValue() == null ? JsonNull.INSTANCE : new JsonPrimitive(hidePasswordValue(event.getNewValue())));
+		}
 		events.add(evt);
 	}
 
@@ -314,4 +326,17 @@ public class GenericDebugListener implements ProcessEventListener, RuleRuntimeEv
 		return new Gson().toJson(retval);
 	}
 	
+	private static String hidePasswordValue(Object value) {
+		if (value == null) {
+			return "null";
+		}
+		String retval = value.toString();
+		//basically, any variable or attribute in the toString that has password is taken and stripped
+		if (retval.toLowerCase().contains("password")) {
+			Pattern pat = java.util.regex.Pattern.compile("assword([^=]*)=([^,\\\\])*");
+			retval = pat.matcher(retval).replaceAll("assword$1=-----");
+		}
+		return retval;
+	}
 }
+

--- a/service-daos/src/main/java/io/elimu/service/dao/jpa/CDSServiceRepository.java
+++ b/service-daos/src/main/java/io/elimu/service/dao/jpa/CDSServiceRepository.java
@@ -48,6 +48,9 @@ public interface CDSServiceRepository extends CrudRepository<ServiceInfo, Servic
 	@Query("from ServiceInfo c where c.id.version in (select max(c1.id.version) from ServiceInfo c1 where c.id.id = c1.id.id) and c.serviceType = 'generic' and c.status = 'done'")
 	Iterable<ServiceInfo> findAllGeneric();
 
+	@Query("select count(c) from ServiceInfo c where c.id.version in (select max(c1.id.version) from ServiceInfo c1 where c.id.id = c1.id.id) and c.serviceType = 'generic' and c.status = 'done'")
+	Integer countAllGeneric();
+
 	@Modifying
 	@Transactional
 	@Query("delete from ServiceInfo c where c.id.id = ?1")


### PR DESCRIPTION
Given the following HTTP headers, you will see debug info from listeners:
1) HTTP Header X-Enable-Debug with value true: The server logs will contain information of listeners for the different rule and process evnets
2) HTTP Header X-Output-Debug with value true: The body of the HTTP response will be a JSON, with one attribute being the initial response, and another one being the events list as JSON output. 

Special attention was added so that the output stored was not exposing variables with the name "password" in them in the HTTP response