### PR TITLE
OperationOutcomeWorkItemHandler 

### DIFF
--- a/fhir-resource-wih/pom.xml
+++ b/fhir-resource-wih/pom.xml
@@ -132,6 +132,10 @@
 			   <version>2.8.5</version>
 		</dependency>
 		<dependency>
+			<groupId>io.elimu.a2d2</groupId>
+			<artifactId>generic-model</artifactId>
+		</dependency>
+		<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
 				<scope>test</scope>

--- a/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/OperationOutcomeDelegate.java
+++ b/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/OperationOutcomeDelegate.java
@@ -12,7 +12,7 @@ import ca.uhn.fhir.context.FhirContext;
 import io.elimu.a2d2.exception.WorkItemHandlerException;
 import io.elimu.a2d2.genericmodel.ServiceResponse;
 
-public class OperationOutcomeWorkItemHandler implements WorkItemHandler {
+public class OperationOutcomeDelegate implements WorkItemHandler {
 
 	public static final String ISSUE_PREFIX = "issue_";
 	

--- a/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/OperationOutcomeWorkItemHandler.java
+++ b/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/OperationOutcomeWorkItemHandler.java
@@ -1,0 +1,205 @@
+package io.elimu.a2d2.fhirresourcewih;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.runtime.process.WorkItemHandler;
+import org.kie.api.runtime.process.WorkItemManager;
+
+import ca.uhn.fhir.context.FhirContext;
+import io.elimu.a2d2.exception.WorkItemHandlerException;
+import io.elimu.a2d2.genericmodel.ServiceResponse;
+
+public class OperationOutcomeWorkItemHandler implements WorkItemHandler {
+
+	public static final String ISSUE_PREFIX = "issue_";
+	
+	@Override
+	public void executeWorkItem(WorkItem workItem, WorkItemManager manager) {
+		String version = (String) workItem.getParameter("fhirVersion");
+		Object status = workItem.getParameter("response_status");
+		Set<String> issueIds = workItem.getParameters().keySet().stream().
+				filter(e -> e.startsWith(ISSUE_PREFIX)).
+				map(s -> s.replace(ISSUE_PREFIX, "")).
+				map(s -> s.substring(0, s.indexOf("_"))).
+				distinct().
+				collect(Collectors.toSet());
+		Object outcomeObj = null;
+		String outcomeJson = null;
+		if (version == null || "FHIR4".equalsIgnoreCase(version) || "R4".equalsIgnoreCase(version)) {
+			org.hl7.fhir.r4.model.OperationOutcome outcome = new org.hl7.fhir.r4.model.OperationOutcome();
+			for (String issueId : issueIds) {
+				Map<String, Object> subset = extractIssueDetails(workItem.getParameters(), issueId);
+				org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent issue = outcome.addIssue();
+				if (subset.containsKey("code")) {
+					String code = (String) subset.get("code");
+					issue.setCode(org.hl7.fhir.r4.model.OperationOutcome.IssueType.fromCode(code));
+				}
+				if (subset.containsKey("details") || subset.containsKey("detailsCode") || subset.containsKey("detailsSystem")) {
+					String details = (String) subset.get("details");
+					String code = (String) subset.get("detailsCode");
+					String system = (String) subset.get("detailsSystem");
+					org.hl7.fhir.r4.model.CodeableConcept cc = new org.hl7.fhir.r4.model.CodeableConcept();
+					if (code != null || system != null) {
+						org.hl7.fhir.r4.model.Coding coding = cc.addCoding();
+						if (code != null) {
+							coding.setCode(code);
+						}
+						if (system != null) {
+							coding.setSystem(system);
+						}
+					}
+					if (details != null) {
+						cc.setText(details);
+					}
+					issue.setDetails(cc);
+				}
+				if (subset.containsKey("diagnostics")) {
+					issue.setDiagnostics((String) subset.get("diagnostics"));
+				}
+				if (subset.containsKey("location")) {
+					issue.addLocation((String) subset.get("location"));
+				}
+				if (subset.containsKey("location0")) {
+					for (int index = 0; subset.containsKey("location" + index); index++) {
+						issue.addLocation((String) subset.get("location" + index));
+					}
+				}
+				if (subset.containsKey("severity")) {
+					String code = (String) subset.get("severity");
+					issue.setSeverity(org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity.fromCode(code));
+				}
+			}
+			outcomeObj = outcome;
+			outcomeJson = FhirContext.forR4().newJsonParser().encodeResourceToString(outcome);
+		} else if ("FHIR3".equalsIgnoreCase(version) || "DSTU3".equalsIgnoreCase(version)) {
+			org.hl7.fhir.dstu3.model.OperationOutcome outcome = new org.hl7.fhir.dstu3.model.OperationOutcome();
+			for (String issueId : issueIds) {
+				Map<String, Object> subset = extractIssueDetails(workItem.getParameters(), issueId);
+				org.hl7.fhir.dstu3.model.OperationOutcome.OperationOutcomeIssueComponent issue = outcome.addIssue();
+				if (subset.containsKey("code")) {
+					String code = (String) subset.get("code");
+					issue.setCode(org.hl7.fhir.dstu3.model.OperationOutcome.IssueType.fromCode(code));
+				}
+				if (subset.containsKey("details") || subset.containsKey("detailsCode") || subset.containsKey("detailsSystem")) {
+					String details = (String) subset.get("details");
+					String code = (String) subset.get("detailsCode");
+					String system = (String) subset.get("detailsSystem");
+					org.hl7.fhir.dstu3.model.CodeableConcept cc = new org.hl7.fhir.dstu3.model.CodeableConcept();
+					if (code != null || system != null) {
+						org.hl7.fhir.dstu3.model.Coding coding = cc.addCoding();
+						if (code != null) {
+							coding.setCode(code);
+						}
+						if (system != null) {
+							coding.setSystem(system);
+						}
+					}
+					if (details != null) {
+						cc.setText(details);
+					}
+					issue.setDetails(cc);
+				}
+				if (subset.containsKey("diagnostics")) {
+					issue.setDiagnostics((String) subset.get("diagnostics"));
+				}
+				if (subset.containsKey("location")) {
+					issue.addLocation((String) subset.get("location"));
+				}
+				if (subset.containsKey("location0")) {
+					for (int index = 0; subset.containsKey("location" + index); index++) {
+						issue.addLocation((String) subset.get("location" + index));
+					}
+				}
+				if (subset.containsKey("severity")) {
+					String code = (String) subset.get("severity");
+					issue.setSeverity(org.hl7.fhir.dstu3.model.OperationOutcome.IssueSeverity.fromCode(code));
+				}
+			}
+			outcomeObj = outcome;
+			outcomeJson = FhirContext.forDstu3().newJsonParser().encodeResourceToString(outcome);
+		} else if ("FHIR2".equalsIgnoreCase(version) || "DSTU2".equalsIgnoreCase(version)) {
+			ca.uhn.fhir.model.dstu2.resource.OperationOutcome outcome = new ca.uhn.fhir.model.dstu2.resource.OperationOutcome();
+			for (String issueId : issueIds) {
+				Map<String, Object> subset = extractIssueDetails(workItem.getParameters(), issueId);
+				ca.uhn.fhir.model.dstu2.resource.OperationOutcome.Issue issue = outcome.addIssue();
+				if (subset.containsKey("code")) {
+					String code = (String) subset.get("code");
+					issue.setCode(ca.uhn.fhir.model.dstu2.valueset.IssueTypeEnum.forCode(code));
+				}
+				if (subset.containsKey("details") || subset.containsKey("detailsCode") || subset.containsKey("detailsSystem")) {
+					String details = (String) subset.get("details");
+					String code = (String) subset.get("detailsCode");
+					String system = (String) subset.get("detailsSystem");
+					ca.uhn.fhir.model.dstu2.composite.CodeableConceptDt cc = new ca.uhn.fhir.model.dstu2.composite.CodeableConceptDt();
+					if (code != null || system != null) {
+						ca.uhn.fhir.model.dstu2.composite.CodingDt coding = cc.addCoding();
+						if (code != null) {
+							coding.setCode(code);
+						}
+						if (system != null) {
+							coding.setSystem(system);
+						}
+					}
+					if (details != null) {
+						cc.setText(details);
+					}
+					issue.setDetails(cc);
+				}
+				if (subset.containsKey("diagnostics")) {
+					issue.setDiagnostics((String) subset.get("diagnostics"));
+				}
+				if (subset.containsKey("location")) {
+					issue.addLocation((String) subset.get("location"));
+				}
+				if (subset.containsKey("location0")) {
+					for (int index = 0; subset.containsKey("location" + index); index++) {
+						issue.addLocation((String) subset.get("location" + index));
+					}
+				}
+				if (subset.containsKey("severity")) {
+					String code = (String) subset.get("severity");
+					issue.setSeverity(ca.uhn.fhir.model.dstu2.valueset.IssueSeverityEnum.forCode(code));
+				}
+			}
+			outcomeObj = outcome;
+			outcomeJson = FhirContext.forDstu2().newJsonParser().encodeResourceToString(outcome);
+		} else {
+			throw new WorkItemHandlerException("Unrecognized fhirVersion attribute: '" + version + "'");
+		}
+		Map<String, Object> results = workItem.getResults();
+		results.put("outcome", outcomeObj);
+		results.put("outcomeJson", outcomeJson);
+		ServiceResponse serviceResponse = new ServiceResponse();
+		serviceResponse.setBody(outcomeJson);
+		serviceResponse.addHeaderValue("Content-Type", "application/json");
+		serviceResponse.setResponseCode(responseCode(status));
+		results.put("serviceResponse", serviceResponse);
+		manager.completeWorkItem(workItem.getId(), results);
+	}
+
+	private Integer responseCode(Object status) {
+		int retval = 200;
+		if (status != null) {
+			try {
+				retval = Integer.valueOf(status.toString());
+			} catch (Exception ignore) { }
+		}
+		return retval;
+	}
+
+	public static Map<String, Object> extractIssueDetails(Map<String, Object> params, String issueId) {
+		return params.entrySet().stream().
+				filter(e -> e.getKey().startsWith(ISSUE_PREFIX + issueId + "_")).
+				collect(Collectors.toMap(
+						e -> e.getKey().replace(ISSUE_PREFIX + issueId + "_", ""), 
+						e -> e.getValue()));
+	}
+	
+	@Override
+	public void abortWorkItem(WorkItem workItem, WorkItemManager manager) {
+		// do nothing
+	}
+}

--- a/fhir-resource-wih/src/test/java/io/elimu/a2d2/fhir_resource_wih/OpOutcomeWIHTest.java
+++ b/fhir-resource-wih/src/test/java/io/elimu/a2d2/fhir_resource_wih/OpOutcomeWIHTest.java
@@ -12,15 +12,15 @@ import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
 
 import io.elimu.a2d2.exception.WorkItemHandlerException;
-import io.elimu.a2d2.fhirresourcewih.OperationOutcomeWorkItemHandler;
+import io.elimu.a2d2.fhirresourcewih.OperationOutcomeDelegate;
 
 public class OpOutcomeWIHTest {
 
 	@Test
 	public void testEmptyMap() {
 		Map<String, Object> params = new HashMap<>();
-		Map<String, Object> a = OperationOutcomeWorkItemHandler.extractIssueDetails(params, "a");
-		Map<String, Object> a1 = OperationOutcomeWorkItemHandler.extractIssueDetails(params, "a1");
+		Map<String, Object> a = OperationOutcomeDelegate.extractIssueDetails(params, "a");
+		Map<String, Object> a1 = OperationOutcomeDelegate.extractIssueDetails(params, "a1");
 		Assert.assertNotNull(a);
 		Assert.assertTrue(a.isEmpty());
 		Assert.assertNotNull(a1);
@@ -37,8 +37,8 @@ public class OpOutcomeWIHTest {
 		params.put("issue_a1_detailsSystem", "abcde");
 		params.put("issue_a1_location0", "somewhere");
 		params.put("issue_a1_location1", "overtherainbow");
-		Map<String, Object> a = OperationOutcomeWorkItemHandler.extractIssueDetails(params, "a");
-		Map<String, Object> a1 = OperationOutcomeWorkItemHandler.extractIssueDetails(params, "a1");
+		Map<String, Object> a = OperationOutcomeDelegate.extractIssueDetails(params, "a");
+		Map<String, Object> a1 = OperationOutcomeDelegate.extractIssueDetails(params, "a1");
 		Assert.assertNotNull(a);
 		Assert.assertTrue(a.containsKey("code"));
 		Assert.assertTrue(a.containsKey("diagnostics"));
@@ -61,7 +61,7 @@ public class OpOutcomeWIHTest {
 		params.put("issue_a_location", "somewhere");;
 		params.put("issue_a1_location0", "somewhere");
 		params.put("issue_a1_location1", "overtherainbow");
-		OperationOutcomeWorkItemHandler handler = new OperationOutcomeWorkItemHandler();
+		OperationOutcomeDelegate handler = new OperationOutcomeDelegate();
 		WorkItemManager manager = new DoNothingWorkItemManager();
 		handler.executeWorkItem(workItem, manager);
 		Map<String, Object> results = workItem.getResults();
@@ -85,7 +85,7 @@ public class OpOutcomeWIHTest {
 		Map<String, Object> params = workItem.getParameters();
 		params.put("fhirVersion", "FHIR4");
 		params.put("issue_a_code", "informational");
-		OperationOutcomeWorkItemHandler handler = new OperationOutcomeWorkItemHandler();
+		OperationOutcomeDelegate handler = new OperationOutcomeDelegate();
 		WorkItemManager manager = new DoNothingWorkItemManager();
 		handler.executeWorkItem(workItem, manager);
 		Map<String, Object> results = workItem.getResults();
@@ -100,7 +100,7 @@ public class OpOutcomeWIHTest {
 		Map<String, Object> params = workItem.getParameters();
 		params.put("fhirVersion", "R4");
 		params.put("issue_a_code", "informational");
-		OperationOutcomeWorkItemHandler handler = new OperationOutcomeWorkItemHandler();
+		OperationOutcomeDelegate handler = new OperationOutcomeDelegate();
 		WorkItemManager manager = new DoNothingWorkItemManager();
 		handler.executeWorkItem(workItem, manager);
 		Map<String, Object> results = workItem.getResults();
@@ -115,7 +115,7 @@ public class OpOutcomeWIHTest {
 		Map<String, Object> params = workItem.getParameters();
 		params.put("fhirVersion", "DSTU3");
 		params.put("issue_a_code", "informational");
-		OperationOutcomeWorkItemHandler handler = new OperationOutcomeWorkItemHandler();
+		OperationOutcomeDelegate handler = new OperationOutcomeDelegate();
 		WorkItemManager manager = new DoNothingWorkItemManager();
 		handler.executeWorkItem(workItem, manager);
 		Map<String, Object> results = workItem.getResults();
@@ -138,7 +138,7 @@ public class OpOutcomeWIHTest {
 		params.put("issue_a1_detailsSystem", "abcde");
 		params.put("issue_a1_location0", "somewhere");
 		params.put("issue_a1_location1", "overtherainbow");
-		OperationOutcomeWorkItemHandler handler = new OperationOutcomeWorkItemHandler();
+		OperationOutcomeDelegate handler = new OperationOutcomeDelegate();
 		WorkItemManager manager = new DoNothingWorkItemManager();
 		handler.executeWorkItem(workItem, manager);
 		Map<String, Object> results = workItem.getResults();
@@ -163,7 +163,7 @@ public class OpOutcomeWIHTest {
 		WorkItemImpl workItem = new WorkItemImpl();
 		Map<String, Object> params = workItem.getParameters();
 		params.put("fhirVersion", "Fhir9000");
-		OperationOutcomeWorkItemHandler handler = new OperationOutcomeWorkItemHandler();
+		OperationOutcomeDelegate handler = new OperationOutcomeDelegate();
 		WorkItemManager manager = new DoNothingWorkItemManager();
 		handler.executeWorkItem(workItem, manager);
 	}
@@ -182,7 +182,7 @@ public class OpOutcomeWIHTest {
 		params.put("issue_a1_detailsSystem", "abcde");
 		params.put("issue_a1_location0", "somewhere");
 		params.put("issue_a1_location1", "overtherainbow");
-		OperationOutcomeWorkItemHandler handler = new OperationOutcomeWorkItemHandler();
+		OperationOutcomeDelegate handler = new OperationOutcomeDelegate();
 		WorkItemManager manager = new DoNothingWorkItemManager();
 		handler.executeWorkItem(workItem, manager);
 		Map<String, Object> results = workItem.getResults();
@@ -206,7 +206,7 @@ public class OpOutcomeWIHTest {
 		Map<String, Object> params = workItem.getParameters();
 		params.put("fhirVersion", "DSTU2");
 		params.put("issue_a_code", "informational");
-		OperationOutcomeWorkItemHandler handler = new OperationOutcomeWorkItemHandler();
+		OperationOutcomeDelegate handler = new OperationOutcomeDelegate();
 		WorkItemManager manager = new DoNothingWorkItemManager();
 		handler.executeWorkItem(workItem, manager);
 		Map<String, Object> results = workItem.getResults();

--- a/fhir-resource-wih/src/test/java/io/elimu/a2d2/fhir_resource_wih/OpOutcomeWIHTest.java
+++ b/fhir-resource-wih/src/test/java/io/elimu/a2d2/fhir_resource_wih/OpOutcomeWIHTest.java
@@ -1,0 +1,223 @@
+package io.elimu.a2d2.fhir_resource_wih;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.drools.core.process.instance.impl.WorkItemImpl;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent;
+import org.junit.Assert;
+import org.junit.Test;
+import org.kie.api.runtime.process.WorkItemHandler;
+import org.kie.api.runtime.process.WorkItemManager;
+
+import io.elimu.a2d2.exception.WorkItemHandlerException;
+import io.elimu.a2d2.fhirresourcewih.OperationOutcomeWorkItemHandler;
+
+public class OpOutcomeWIHTest {
+
+	@Test
+	public void testEmptyMap() {
+		Map<String, Object> params = new HashMap<>();
+		Map<String, Object> a = OperationOutcomeWorkItemHandler.extractIssueDetails(params, "a");
+		Map<String, Object> a1 = OperationOutcomeWorkItemHandler.extractIssueDetails(params, "a1");
+		Assert.assertNotNull(a);
+		Assert.assertTrue(a.isEmpty());
+		Assert.assertNotNull(a1);
+		Assert.assertTrue(a1.isEmpty());
+	}
+
+	@Test
+	public void testExtractionFromMap() {
+		Map<String, Object> params = new HashMap<>();
+		params.put("issue_a_code", "1234");
+		params.put("issue_a_diagnostics", "something");
+		params.put("issue_a1_details", "abcde");
+		params.put("issue_a1_detailsCode", "abcde");
+		params.put("issue_a1_detailsSystem", "abcde");
+		params.put("issue_a1_location0", "somewhere");
+		params.put("issue_a1_location1", "overtherainbow");
+		Map<String, Object> a = OperationOutcomeWorkItemHandler.extractIssueDetails(params, "a");
+		Map<String, Object> a1 = OperationOutcomeWorkItemHandler.extractIssueDetails(params, "a1");
+		Assert.assertNotNull(a);
+		Assert.assertTrue(a.containsKey("code"));
+		Assert.assertTrue(a.containsKey("diagnostics"));
+		Assert.assertNotNull(a1);
+		Assert.assertTrue(a1.containsKey("details"));
+		Assert.assertTrue(a1.containsKey("location0"));
+		Assert.assertTrue(a1.containsKey("location1"));
+	}
+	
+	@Test
+	public void testGenerateOutcome() {
+		WorkItemImpl workItem = new WorkItemImpl();
+		Map<String, Object> params = workItem.getParameters();
+		params.put("issue_a_code", "informational");
+		params.put("issue_a_diagnostics", "something");
+		params.put("issue_a_severity", "warning");
+		params.put("issue_a1_details", "abcde");
+		params.put("issue_a1_detailsCode", "abcde");
+		params.put("issue_a1_detailsSystem", "abcde");
+		params.put("issue_a_location", "somewhere");;
+		params.put("issue_a1_location0", "somewhere");
+		params.put("issue_a1_location1", "overtherainbow");
+		OperationOutcomeWorkItemHandler handler = new OperationOutcomeWorkItemHandler();
+		WorkItemManager manager = new DoNothingWorkItemManager();
+		handler.executeWorkItem(workItem, manager);
+		Map<String, Object> results = workItem.getResults();
+		Assert.assertNotNull(results);
+		Assert.assertNotNull(results.get("outcome"));
+		Assert.assertNotNull(results.get("outcomeJson"));
+		Assert.assertTrue(results.get("outcomeJson") instanceof String);
+		Assert.assertTrue(results.get("outcome") instanceof OperationOutcome);
+		OperationOutcome oo = (OperationOutcome) results.get("outcome");
+		Assert.assertNotNull(oo.getIssue());
+		Assert.assertEquals(2, oo.getIssue().size());
+		OperationOutcomeIssueComponent issue1 = (OperationOutcomeIssueComponent) oo.getIssue().get(0);
+		OperationOutcomeIssueComponent issue2 = (OperationOutcomeIssueComponent) oo.getIssue().get(1);
+		Assert.assertNotNull(issue1);
+		Assert.assertNotNull(issue2);
+	}
+
+	@Test
+	public void testGenerateOutcomeFHIR4() {
+		WorkItemImpl workItem = new WorkItemImpl();
+		Map<String, Object> params = workItem.getParameters();
+		params.put("fhirVersion", "FHIR4");
+		params.put("issue_a_code", "informational");
+		OperationOutcomeWorkItemHandler handler = new OperationOutcomeWorkItemHandler();
+		WorkItemManager manager = new DoNothingWorkItemManager();
+		handler.executeWorkItem(workItem, manager);
+		Map<String, Object> results = workItem.getResults();
+		Assert.assertNotNull(results);
+		Assert.assertNotNull(results.get("outcome"));
+		Assert.assertNotNull(results.get("outcomeJson"));
+	}
+
+	@Test
+	public void testGenerateOutcomeR4() {
+		WorkItemImpl workItem = new WorkItemImpl();
+		Map<String, Object> params = workItem.getParameters();
+		params.put("fhirVersion", "R4");
+		params.put("issue_a_code", "informational");
+		OperationOutcomeWorkItemHandler handler = new OperationOutcomeWorkItemHandler();
+		WorkItemManager manager = new DoNothingWorkItemManager();
+		handler.executeWorkItem(workItem, manager);
+		Map<String, Object> results = workItem.getResults();
+		Assert.assertNotNull(results);
+		Assert.assertNotNull(results.get("outcome"));
+		Assert.assertNotNull(results.get("outcomeJson"));
+	}
+
+	@Test
+	public void testGenerateOutcomeDSTU3() {
+		WorkItemImpl workItem = new WorkItemImpl();
+		Map<String, Object> params = workItem.getParameters();
+		params.put("fhirVersion", "DSTU3");
+		params.put("issue_a_code", "informational");
+		OperationOutcomeWorkItemHandler handler = new OperationOutcomeWorkItemHandler();
+		WorkItemManager manager = new DoNothingWorkItemManager();
+		handler.executeWorkItem(workItem, manager);
+		Map<String, Object> results = workItem.getResults();
+		Assert.assertNotNull(results);
+		Assert.assertNotNull(results.get("outcome"));
+		Assert.assertNotNull(results.get("outcomeJson"));
+	}
+	
+	@Test
+	public void testGenerateOutcomeV3() {
+		WorkItemImpl workItem = new WorkItemImpl();
+		Map<String, Object> params = workItem.getParameters();
+		params.put("fhirVersion", "Fhir3");
+		params.put("issue_a_code", "informational");
+		params.put("issue_a_diagnostics", "something");
+		params.put("issue_a_location", "somewhere");;
+		params.put("issue_a_severity", "warning");
+		params.put("issue_a1_details", "abcde");
+		params.put("issue_a1_detailsCode", "abcde");
+		params.put("issue_a1_detailsSystem", "abcde");
+		params.put("issue_a1_location0", "somewhere");
+		params.put("issue_a1_location1", "overtherainbow");
+		OperationOutcomeWorkItemHandler handler = new OperationOutcomeWorkItemHandler();
+		WorkItemManager manager = new DoNothingWorkItemManager();
+		handler.executeWorkItem(workItem, manager);
+		Map<String, Object> results = workItem.getResults();
+		Assert.assertNotNull(results);
+		Assert.assertNotNull(results.get("outcome"));
+		Assert.assertNotNull(results.get("outcomeJson"));
+		Assert.assertTrue(results.get("outcomeJson") instanceof String);
+		Assert.assertTrue(results.get("outcome") instanceof org.hl7.fhir.dstu3.model.OperationOutcome);
+		org.hl7.fhir.dstu3.model.OperationOutcome oo = (org.hl7.fhir.dstu3.model.OperationOutcome) results.get("outcome");
+		Assert.assertNotNull(oo.getIssue());
+		Assert.assertEquals(2, oo.getIssue().size());
+		org.hl7.fhir.dstu3.model.OperationOutcome.OperationOutcomeIssueComponent issue1 = 
+				(org.hl7.fhir.dstu3.model.OperationOutcome.OperationOutcomeIssueComponent) oo.getIssue().get(0);
+		org.hl7.fhir.dstu3.model.OperationOutcome.OperationOutcomeIssueComponent issue2 = 
+				(org.hl7.fhir.dstu3.model.OperationOutcome.OperationOutcomeIssueComponent) oo.getIssue().get(1);
+		Assert.assertNotNull(issue1);
+		Assert.assertNotNull(issue2);
+	}
+
+	@Test(expected = WorkItemHandlerException.class)
+	public void testGenerateOutcomeV9() {
+		WorkItemImpl workItem = new WorkItemImpl();
+		Map<String, Object> params = workItem.getParameters();
+		params.put("fhirVersion", "Fhir9000");
+		OperationOutcomeWorkItemHandler handler = new OperationOutcomeWorkItemHandler();
+		WorkItemManager manager = new DoNothingWorkItemManager();
+		handler.executeWorkItem(workItem, manager);
+	}
+	
+	@Test
+	public void testGenerateOutcomeV2() {
+		WorkItemImpl workItem = new WorkItemImpl();
+		Map<String, Object> params = workItem.getParameters();
+		params.put("fhirVersion", "Fhir2");
+		params.put("issue_a_code", "informational");
+		params.put("issue_a_diagnostics", "something");
+		params.put("issue_a_severity", "warning");
+		params.put("issue_a_location", "somewhere");;
+		params.put("issue_a1_details", "abcde");
+		params.put("issue_a1_detailsCode", "abcde");
+		params.put("issue_a1_detailsSystem", "abcde");
+		params.put("issue_a1_location0", "somewhere");
+		params.put("issue_a1_location1", "overtherainbow");
+		OperationOutcomeWorkItemHandler handler = new OperationOutcomeWorkItemHandler();
+		WorkItemManager manager = new DoNothingWorkItemManager();
+		handler.executeWorkItem(workItem, manager);
+		Map<String, Object> results = workItem.getResults();
+		Assert.assertNotNull(results);
+		Assert.assertNotNull(results.get("outcome"));
+		Assert.assertNotNull(results.get("outcomeJson"));
+		Assert.assertTrue(results.get("outcomeJson") instanceof String);
+		Assert.assertTrue(results.get("outcome") instanceof ca.uhn.fhir.model.dstu2.resource.OperationOutcome);
+		ca.uhn.fhir.model.dstu2.resource.OperationOutcome oo = (ca.uhn.fhir.model.dstu2.resource.OperationOutcome) results.get("outcome");
+		Assert.assertNotNull(oo.getIssue());
+		Assert.assertEquals(2, oo.getIssue().size());
+		ca.uhn.fhir.model.dstu2.resource.OperationOutcome.Issue issue1 =  (ca.uhn.fhir.model.dstu2.resource.OperationOutcome.Issue) oo.getIssue().get(0);
+		ca.uhn.fhir.model.dstu2.resource.OperationOutcome.Issue issue2 = (ca.uhn.fhir.model.dstu2.resource.OperationOutcome.Issue) oo.getIssue().get(1);
+		Assert.assertNotNull(issue1);
+		Assert.assertNotNull(issue2);
+	}
+
+	@Test
+	public void testGenerateOutcomeDSTU2() {
+		WorkItemImpl workItem = new WorkItemImpl();
+		Map<String, Object> params = workItem.getParameters();
+		params.put("fhirVersion", "DSTU2");
+		params.put("issue_a_code", "informational");
+		OperationOutcomeWorkItemHandler handler = new OperationOutcomeWorkItemHandler();
+		WorkItemManager manager = new DoNothingWorkItemManager();
+		handler.executeWorkItem(workItem, manager);
+		Map<String, Object> results = workItem.getResults();
+		Assert.assertNotNull(results);
+		Assert.assertNotNull(results.get("outcome"));
+		Assert.assertNotNull(results.get("outcomeJson"));
+	}
+	
+	public static class DoNothingWorkItemManager implements WorkItemManager {
+		@Override public void completeWorkItem(long id, Map<String, Object> results) { }
+		@Override public void abortWorkItem(long id) { }
+		@Override public void registerWorkItemHandler(String workItemName, WorkItemHandler handler) { }
+	}
+}


### PR DESCRIPTION
This OperaitonOutcomeWorkItemHandler will generate three things:
 - An OperationOutcome FHIR object
 - A JSON containing variable
 - A ServiceResponse object prepared to return an OperationOutcome
The expected inputs are:
 - fhirVersion: optional, by default it will use R4. Will expect values FHIR2, FHIR3, FHIR4, DSTU2, DSTU3, R4
 - response_status: an Integer with the HTTP status to return (if a ServiceResponse is the output expected)
And a set of variable inputs starting with issue_, any identifier ending in _, and a set of key names for allowing different issue elements, like this:
 - issue_a_code: The issue type
 - issue_a_details: The details CodeableConcept’s text attribute
 - issue_a_detailsCode: The details CodeableConcept’s code attribute
 - issue_a_detailsSystem: The details CodeableConcept’s system attribute
 - issue_a_diagnostics: The diagnostics attirbute
 - issue_a_location: A single location for the issue
 - issue_a_location0, issue_a_location1, …, issue_a_locationN: multiple locaitons for the issue
 - issue_a_severity: the severity attribute code