### PR TITLE
Updated version of dependency-check-maven to 6.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -411,7 +411,7 @@
 			<plugin>
 				<groupId>org.owasp</groupId>
 				<artifactId>dependency-check-maven</artifactId>
-				<version>5.3.2</version>
+				<version>6.2.2</version>
 				<configuration>
 				<skipProvidedScope>true</skipProvidedScope>
 				<skipRuntimeScope>true</skipRuntimeScope>


### PR DESCRIPTION
Running "mvn site" with version 5.3.2 generates the following error :
"[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.7.1:site (default-site) on project parent: Error generating dependency-check-maven:5.3.2:aggregate report: One or more exceptions occurred during dependency-check analysis: One or more exceptions occurred during analysis:
[ERROR] Unable to resolve system scoped dependency: com.sun:tools:jar:1.8.0:system"

Updating to 6.2.2 resolves that.