### PR TITLE
Updated A2D2 Springboot to 2.4.8 and resolved dependencies.

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -27,7 +27,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.9.RELEASE</version>
+		<version>2.4.8</version>
 	</parent>
 
 	<properties>
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.10.5</version>
+			<version>2.11.4</version>
 		</dependency>	
 		<dependency> 
 			<groupId>com.mchange</groupId>
@@ -144,7 +144,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -344,6 +344,12 @@
 			<groupId>com.j256.cloudwatchlogbackappender</groupId>
 			<artifactId>cloudwatchlogbackappender</artifactId>
 			<version>1.11</version>
+			<exclusions>
+				<exclusion>
+					<groupId>joda-time</groupId>
+					<artifactId>joda-time</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		
 		<!--leave this for now as backward compatibility concerns, remove after fixing omnibus A2D2-584 -->

--- a/cds-hook-services/pom.xml
+++ b/cds-hook-services/pom.xml
@@ -30,7 +30,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-parent</artifactId>
-				<version>2.2.9.RELEASE</version>
+				<version>2.4.8</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/cds-integration/pom.xml
+++ b/cds-integration/pom.xml
@@ -9,9 +9,9 @@
         <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <version.junit>4.12</version.junit>
+        <version.junit>4.13.2</version.junit>
         <version.shrinkwrap-resolver-depchain>2.2.2</version.shrinkwrap-resolver-depchain>
-        <version.spring-boot-starter-web>2.2.9.RELEASE</version.spring-boot-starter-web>
+        <version.spring-boot-starter-web>2.4.8</version.spring-boot-starter-web>
         <version.assertj-core>2.5.0</version.assertj-core>
         <version.awaitility>2.0.0</version.awaitility>
         <version.rest-assured>3.0.1</version.rest-assured>

--- a/fhir-helpers/pom.xml
+++ b/fhir-helpers/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -377,7 +377,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
     			<artifactId>junit-jupiter-api</artifactId>
-    			<version>5.5.2</version>
+    			<version>5.7.2</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,12 @@
 		<jdk.version>1.8</jdk.version>
 		<kie.version>7.50.0.Final</kie.version>
 		<wb.kie.version>7.50.0.Final</wb.kie.version>
-		<junit.version>4.12</junit.version>
+		<junit.version>4.13.2</junit.version>
 		<hapi.fhir.version>3.8.0</hapi.fhir.version>
 		<json-simple.version>1.1.1</json-simple.version>
 		<h2.version>1.4.193</h2.version>
 		<hibernate.version>5.1.17.Final</hibernate.version>
-		<spring.boot.starter.version>2.2.9.RELEASE</spring.boot.starter.version>
+		<spring.boot.starter.version>2.4.8</spring.boot.starter.version>
 		<jackson.version>2.9.10.5</jackson.version>
 		<mockito.version>2.23.0</mockito.version>
 		<jedis.version>3.2.0</jedis.version>

--- a/service-daos/pom.xml
+++ b/service-daos/pom.xml
@@ -30,7 +30,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-parent</artifactId>
-				<version>2.2.9.RELEASE</version>
+				<version>2.4.8</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/task-utilities/pom.xml
+++ b/task-utilities/pom.xml
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Springboot 2.2.9 was released a year ago. This change brings Springboot to 2.4.8 which does many bug fixes and dependency upgrades(https://github.com/spring-projects/spring-boot/releases/tag/v2.4.8).

I've run unit tests locally.