### PR TITLE
Added maven-site plug in to fhir-helpers

### DIFF
--- a/fhir-helpers/pom.xml
+++ b/fhir-helpers/pom.xml
@@ -103,6 +103,11 @@
 					<target>1.8</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-site-plugin</artifactId>
+				<version>3.7.1</version>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
Resolved the following error:
 "Execution default-site of goal org.apache.maven.plugins:maven-site-plugin:3.3:site failed: A required class was missing while executing org.apache.maven.plugins:maven-site-plugin:3.3:site: org/apache/maven/doxia/siterenderer/DocumentContent"

I've run tests locally.
