### PR TITLE
Mitigated dependency vulnerabilities caused by bcprov-jdk15on-1.51.jar, updated versions

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -139,7 +139,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk15on</artifactId>
-			<version>1.51</version>
+			<version>1.61</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Vulnerability IDs:
cpe:2.3:a:bouncycastle:legion-of-the-bouncy-castle:1.51:*:*:*:*:*:*:*
cpe:2.3:a:bouncycastle:legion-of-the-bouncy-castle-java-crytography-api:1.51:*:*:*:*:*:*:*

Resolved by upgrading to version 1.61.
I've run tests locally.