### PR TITLE
Mitigate dependency vulnerabilities caused by resteasy-core-4.5.2.Final.jar, json-sanitizer-1.2.0.jar and jackson-databind-2.9.10.5.jar

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -217,7 +217,7 @@
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-client</artifactId>
-			<version>4.5.2.Final</version>
+			<version>4.6.0.Final</version>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-io</groupId>

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -456,7 +456,7 @@
 		<dependency>
 			<groupId>com.mikesamuel</groupId>
 			<artifactId>json-sanitizer</artifactId>
-			<version>1.2.0</version>
+			<version>1.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<h2.version>1.4.193</h2.version>
 		<hibernate.version>5.1.17.Final</hibernate.version>
 		<spring.boot.starter.version>2.4.8</spring.boot.starter.version>
-		<jackson.version>2.9.10.5</jackson.version>
+		<jackson.version>2.9.10.8</jackson.version>
 		<mockito.version>2.23.0</mockito.version>
 		<jedis.version>3.2.0</jedis.version>
 		<cds.helper.version>0.0.6</cds.helper.version>


### PR DESCRIPTION
1. resteasy-core-4.5.2.Final.jar
    Vulnerability IDs:
    cpe:2.3:a:redhat:resteasy:4.5.2:*:*:*:*:*:*:*
    Resolved by upgrading to version 4.6.0.

2. json-sanitizer-1.2.0.jar
    Vulnerability IDs:  
    cpe:2.3:a:owasp:json-sanitizer:1.2.0:*:*:*:*:*:*:*
    Resolved by upgrading to version 1.2.2.

3. jackson-databind-2.9.10.5.jar
    Vulnerability IDs:  
    cpe:2.3:a:fasterxml:jackson-databind:2.9.10.5:*:*:*:*:*:*:*
    cpe:2.3:a:fasterxml:jackson-modules-java8:2.9.10.5:*:*:*:*:*:*:*
    Resolved by upgrading to version 2.9.10.8.


I've run tests locally