### PR TITLE
Mitigated dependency vulnerabilities caused by spring-core-5.2.6.RELEASE.jar and cxf-core-3.2.14.jar

### DIFF
--- a/core-wih/pom.xml
+++ b/core-wih/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>5.2.6.RELEASE</version>
+			<version>5.3.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -14,7 +14,7 @@
 	<description>Kie Based Services</description>
 
 	<properties>
-		<cxf.version>3.2.14</cxf.version>
+		<cxf.version>3.3.11</cxf.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION

1. spring-core-5.2.6.RELEASE.jar
Vulnerability IDs:
    cpe:2.3:a:pivotal_software:spring_framework:5.2.6:release:*:*:*:*:*:*
    cpe:2.3:a:springsource:spring_framework:5.2.6:release:*:*:*:*:*:*
    cpe:2.3:a:vmware:spring_framework:5.2.6:release:*:*:*:*:*:*
    cpe:2.3:a:vmware:springsource_spring_framework:5.2.6:release:*:*:*:*:*:*
Resolved by upgrading to version 5.3.8

2. cxf-core-3.2.14.jar
Vulnerability IDs:
   cpe:2.3:a:apache:cxf:3.2.14:*:*:*:*:*:*:*
Resolved by upgrading to version 3.3.11

I've run tests locally.