### PR TITLE
Removed duplicate entry in ftl-transform-wih/pom.xml

### DIFF
--- a/ftl-transform-wih/pom.xml
+++ b/ftl-transform-wih/pom.xml
@@ -98,10 +98,6 @@
 		</dependency>
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
-			<artifactId>cds-hook-model</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>kie-based-services</artifactId>
 			<exclusions>
 				<exclusion>


### PR DESCRIPTION
build warning message:

[WARNING] Some problems were encountered while building the effective model for io.elimu.a2d2:ftl-transform-wih:jar:0.0.1-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.elimu.a2d2:cds-hook-model:jar -> duplicate declaration of version (?) @ line 132, column 15
[WARNING]

solution: remove duplicate entry