### PR TITLE
Use openjdk11:jre-11.0.10_9-alpine as a2d2 docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV NEXUS_USERNAME $NEXUS_USERNAME
 RUN mvn clean install -DskipTests --settings=./a2d2-settings.xml
 RUN for file in /usr/src/services/*; do mvn clean install -f "$file" --settings=a2d2-settings.xml -Dmaven.repo.local=client_repo;   done 
 
-FROM adoptopenjdk/openjdk11:alpine-jre as final
+FROM adoptopenjdk/openjdk11:jre-11.0.10_9-alpine as final
 
 WORKDIR /app
 


### PR DESCRIPTION
Starting on April 20, 2021, quarterly update releases of OpenJDK are disabling TLS1.0 and TLS1.1 availability by default. This could cause SSL connection problems. Switch to an older image.

I have tested locally 