### PR TITLE
Mitigated dependency vulnerabilities caused by com.thoughtworks.xstream.xstream.1.4.17 and org.jsoup.jsoup.1.12.1

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
-			<version>1.4.17</version>
+			<version>1.4.18</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -451,7 +451,7 @@
 		<dependency>
 			<groupId>org.jsoup</groupId>
 			<artifactId>jsoup</artifactId>
-			<version>1.12.1</version>
+			<version>1.14.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.mikesamuel</groupId>


### PR DESCRIPTION
Resolved high and critical vulnerabilty in omnibus