### PR TITLE
Async true enabling on processes

### DIFF
--- a/kie-based-services/src/main/java/io/elimu/serviceapi/service/AbstractKieService.java
+++ b/kie-based-services/src/main/java/io/elimu/serviceapi/service/AbstractKieService.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.Executors;
 
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
@@ -61,6 +62,7 @@ public abstract class AbstractKieService {
 	private static PoolingDataSource pds = null;
 	private static final Object lock = new Object();
 	private static final int TRANSACTION_TIMEOUT = Integer.parseInt(System.getProperty("bitronix.tm.timer.defaultTransactionTimeout", "600"));
+	private static final int THREADPOOL_COUNT = Integer.parseInt(System.getProperty("elimu.async.threadpool.count", "3"));
 	
 	private RuntimeManager manager;
 	private KieBase kbase;
@@ -179,6 +181,7 @@ public abstract class AbstractKieService {
 				addEnvironmentEntry(EnvironmentName.TRANSACTION_MANAGER, tm).
 				addEnvironmentEntry(EnvironmentName.TRANSACTION, tm).
 				addEnvironmentEntry(EnvironmentName.TRANSACTION_SYNCHRONIZATION_REGISTRY, tsr).
+				addEnvironmentEntry("ExecutorService", Executors.newFixedThreadPool(THREADPOOL_COUNT)).
 				schedulerService(new QuartzSchedulerService()).
 				registerableItemsFactory(new ConfigRegisterableItemsFactory(kContainer, dep.getArtifactId(), deployDescriptor, shouldLogExecution(), getConfig())).
 				knowledgeBase(this.kbase).


### PR DESCRIPTION
This config change allows us to run task definitions in the BPMN files set with async = true, in a separate thread.  