### PR TITLE
GT-557 updated so it filters out 'landlines' as well

### DIFF
--- a/sms-wih/src/main/java/io/elimu/a2d2/smswih/PhoneValidationWorkItemHandler.java
+++ b/sms-wih/src/main/java/io/elimu/a2d2/smswih/PhoneValidationWorkItemHandler.java
@@ -84,13 +84,16 @@ public class PhoneValidationWorkItemHandler implements WorkItemHandler {
 			Twilio.init(sid, auth);
 			PhoneNumber phoneNumber = PhoneNumber.fetcher(
 					new com.twilio.type.PhoneNumber(phone))
-				.setType(Arrays.asList("carrier")).fetch();
+				.setType(Arrays.asList("carrier", "type")).fetch();
 			//here, the phone number is valid
 			//based on country code we can determine nationality
-			workItemResult.put("isValid", phoneNumber.getCarrier().get("error_code") == null);
-			if (phoneNumber.getCarrier().get("error_code") == null) {
+			workItemResult.put("isValid", phoneNumber.getCarrier().get("error_code") == null && !"landline".equalsIgnoreCase(phoneNumber.getCarrier().get("type")));
+			if (phoneNumber.getCarrier().get("error_code") == null && !"landline".equalsIgnoreCase(phoneNumber.getCarrier().get("type"))) {
 				workItemResult.put("isUSANumber", "US".equalsIgnoreCase(phoneNumber.getCountryCode()));
 				workItemResult.put("countryCode", phoneNumber.getCountryCode());
+			} else if ("landline".equalsIgnoreCase(phoneNumber.getCarrier().get("type"))) {
+				workItemResult.put("errorCode", "-1");
+				workItemResult.put("errorMessage", "Phone is a landline, and not SMS enabled");
 			} else {
 				workItemResult.put("errorCode", phoneNumber.getCarrier().get("error_code"));
 				workItemResult.put("errorMessage", parseErrorMessage(phoneNumber.getCarrier().get("error_code")));

--- a/sms-wih/src/test/java/io/elimu/a2d2/smswih/ValidationTest.java
+++ b/sms-wih/src/test/java/io/elimu/a2d2/smswih/ValidationTest.java
@@ -43,7 +43,7 @@ public class ValidationTest {
 		Assert.assertNotNull(workItem.getResult("errorCode"));
 		Assert.assertEquals("-1", workItem.getResult("errorCode"));
 		Assert.assertEquals("Phone is a landline, and not SMS enabled", workItem.getResult("errorMessage"));
-		System.out.println("Phone 3 is not landline");
+		System.out.println("Phone 3 is not SMS enabled");
 	}
 
 	@Test

--- a/sms-wih/src/test/java/io/elimu/a2d2/smswih/ValidationTest.java
+++ b/sms-wih/src/test/java/io/elimu/a2d2/smswih/ValidationTest.java
@@ -33,6 +33,17 @@ public class ValidationTest {
 		Assert.assertEquals("Unprovisioned or out of coverage", workItem.getResult("errorMessage"));
 		Assert.assertEquals("60600", workItem.getResult("errorCode"));
 		System.out.println("Phone 2 is invalid");
+		
+		//workItem.setParameter("phone", "12035024615");
+		workItem.setParameter("phone", "18042221111");
+		handler.executeWorkItem(workItem, new NoOpWorkItemManager());
+		Assert.assertNotNull(workItem.getResult("isValid"));
+		Assert.assertEquals(Boolean.FALSE, workItem.getResult("isValid"));
+		Assert.assertNotNull(workItem.getResult("errorMessage"));
+		Assert.assertNotNull(workItem.getResult("errorCode"));
+		Assert.assertEquals("-1", workItem.getResult("errorCode"));
+		Assert.assertEquals("Phone is a landline, and not SMS enabled", workItem.getResult("errorMessage"));
+		System.out.println("Phone 3 is not landline");
 	}
 
 	@Test


### PR DESCRIPTION
This will add to the SMS phone Validation WIH that it also checks the given phone is not a "landline" which wouldn't be able to receive SMS messages