### PR TITLE
Gt 476

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -31,12 +31,27 @@
 	</parent>
 
 	<properties>
-		<hapi.fhir.version>3.8.0</hapi.fhir.version>
+		<hapi.fhir.version>5.6.0</hapi.fhir.version>
+		<hapi.fhir.util.version>5.5.7</hapi.fhir.util.version>
 		<!-- <kie.version>7.50.0.Final</kie.version> -->
 		<start-class>io.elimu.a2d2api.A2D2Application</start-class>
 		<jasypt.version>3.0.3</jasypt.version>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+                	<dependency>
+                	        <groupId>ca.uhn.hapi.fhir</groupId>
+                	        <artifactId>hapi-fhir-base</artifactId>
+                	        <version>${hapi.fhir.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>2.8.0</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>org.owasp.encoder</groupId>
@@ -122,8 +137,8 @@
 		<!-- Added for phq9-registry converters to work -->
 		<dependency>
                         <groupId>ca.uhn.hapi.fhir</groupId>
-                        <artifactId>hapi-fhir-utilities</artifactId>
-                        <version>${hapi.fhir.version}</version>
+                        <artifactId>org.hl7.fhir.utilities</artifactId>
+                        <version>${hapi.fhir.util.version}</version>
                 </dependency>
                 <dependency>
                         <groupId>ca.uhn.hapi.fhir</groupId>

--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -165,7 +165,7 @@
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>generic-helpers</artifactId>
-			<version>0.0.3</version>
+			<version>0.0.4</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- web development, including Tomcat and spring-webmvc -->

--- a/cds-hook-model/pom.xml
+++ b/cds-hook-model/pom.xml
@@ -31,6 +31,10 @@
 			<groupId>com.googlecode.json-simple</groupId>
 			<artifactId>json-simple</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+		</dependency>
 		<!-- Avoid more HAPI FHIR dependencies than this one. They
 		     Propagate to the workbench and cause issues on all projects -->
 		<dependency>
@@ -40,6 +44,18 @@
 				<exclusion>
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-databind</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-annotations</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -67,6 +83,10 @@
 					<artifactId>jackson-databind</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
 		</dependency>
 		<!-- Test dependencies -->
 		<dependency>

--- a/fhir-helpers/pom.xml
+++ b/fhir-helpers/pom.xml
@@ -20,7 +20,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.elimu.a2d2</groupId>
 	<artifactId>fhir-helpers</artifactId>
-	<version>0.0.2</version>
+	<version>0.0.3</version>
 	<packaging>jar</packaging>
 	<name>fhir-helpers</name>
 	<url>http://maven.apache.org</url>

--- a/fhir-helpers/pom.xml
+++ b/fhir-helpers/pom.xml
@@ -26,7 +26,8 @@
 	<url>http://maven.apache.org</url>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<hapi.fhir.version>3.8.0</hapi.fhir.version>
+		<hapi.fhir.version>5.6.0</hapi.fhir.version>
+		<hapi.fhir.util.version>5.5.7</hapi.fhir.util.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -62,8 +63,8 @@
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>hapi-fhir-utilities</artifactId>
-			<version>${hapi.fhir.version}</version>
+			<artifactId>org.hl7.fhir.utilities</artifactId>
+			<version>${hapi.fhir.util.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>

--- a/fhir-helpers/src/main/java/io/elimu/a2d2/fhir/FhirTransformHelper.java
+++ b/fhir-helpers/src/main/java/io/elimu/a2d2/fhir/FhirTransformHelper.java
@@ -2,9 +2,9 @@ package io.elimu.a2d2.fhir;
 
 import java.text.SimpleDateFormat;
 
-import org.hl7.fhir.convertors.NullVersionConverterAdvisor40;
-import org.hl7.fhir.convertors.VersionConvertor_10_40;
-import org.hl7.fhir.convertors.VersionConvertor_30_40;
+import org.hl7.fhir.converter.NullVersionConverterAdvisor10_40;
+import org.hl7.fhir.convertors.factory.VersionConvertorFactory_10_40;
+import org.hl7.fhir.convertors.factory.VersionConvertorFactory_30_40;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -385,7 +385,7 @@ public class FhirTransformHelper {
 	 * @return an R4 resource representing the same data
 	 */
 	public static org.hl7.fhir.r4.model.Resource transformDstu3Resource(org.hl7.fhir.dstu3.model.Resource v3res) {
-		return VersionConvertor_30_40.convertResource(v3res, true);
+		return VersionConvertorFactory_30_40.convertResource(v3res);
 	}
 	
 	/**
@@ -407,8 +407,8 @@ public class FhirTransformHelper {
 		dstu2json = dstu2json.replaceAll("\"Female\"", "\"female\"");
 		dstu2json = dstu2json.replaceAll("\"Male\"", "\"male\"");
 		//For Mer
-		org.hl7.fhir.instance.model.Resource v2hl7resource = (org.hl7.fhir.instance.model.Resource) FhirContext.forDstu2Hl7Org().newJsonParser().parseResource(dstu2json);
-		org.hl7.fhir.r4.model.Resource v4resource = new VersionConvertor_10_40(new NullVersionConverterAdvisor40()).convertResource(v2hl7resource);
+		org.hl7.fhir.dstu2.model.Resource v2hl7resource = (org.hl7.fhir.dstu2.model.Resource) FhirContext.forDstu2Hl7Org().newJsonParser().parseResource(dstu2json);
+		org.hl7.fhir.r4.model.Resource v4resource = VersionConvertorFactory_10_40.convertResource(v2hl7resource, new NullVersionConverterAdvisor10_40());
 		return v4resource;
 	}
 }

--- a/fhir-query-helper-base/pom.xml
+++ b/fhir-query-helper-base/pom.xml
@@ -79,7 +79,6 @@
 		<dependency>
     			<groupId>com.fasterxml.jackson.core</groupId>
     			<artifactId>jackson-core</artifactId>
-    			<version>2.10.3</version>
 		</dependency>
 
 		<dependency>

--- a/fhir-query-helper-base/pom.xml
+++ b/fhir-query-helper-base/pom.xml
@@ -27,7 +27,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-base</artifactId>
-	<version>0.0.6</version>
+	<version>0.0.7</version>
 	<description>CDS Helper base</description>
 
 	<properties>

--- a/fhir-query-helper-dstu2/pom.xml
+++ b/fhir-query-helper-dstu2/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-dstu2</artifactId>
-	<version>0.0.6</version>
+	<version>0.0.7</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper</description>
 

--- a/fhir-query-helper-dstu3/pom.xml
+++ b/fhir-query-helper-dstu3/pom.xml
@@ -26,7 +26,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-dstu3</artifactId>
-	<version>0.0.6</version>
+	<version>0.0.7</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper DSTU3</description>
 

--- a/fhir-query-helper-r4/pom.xml
+++ b/fhir-query-helper-r4/pom.xml
@@ -26,7 +26,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-r4</artifactId>
-	<version>0.0.6</version>
+	<version>0.0.7</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper R4</description>
 

--- a/fhir-resource-wih/pom.xml
+++ b/fhir-resource-wih/pom.xml
@@ -101,16 +101,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<!--dependency>
-			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>hapi-fhir-utilities</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-codec</groupId>
-   			 		<artifactId>commons-codec</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency-->
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>cds-hook-model</artifactId>

--- a/fhir-resource-wih/pom.xml
+++ b/fhir-resource-wih/pom.xml
@@ -101,7 +101,7 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
+		<!--dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-utilities</artifactId>
 			<exclusions>
@@ -110,7 +110,7 @@
    			 		<artifactId>commons-codec</artifactId>
 				</exclusion>
 			</exclusions>
-		</dependency>
+		</dependency-->
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>cds-hook-model</artifactId>

--- a/ftl-transform-wih/pom.xml
+++ b/ftl-transform-wih/pom.xml
@@ -67,16 +67,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<!--dependency>
-			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>hapi-fhir-utilities</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-codec</groupId>
-   			 		<artifactId>commons-codec</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency-->
 		<dependency>
 			<groupId>org.kie</groupId>
 			<artifactId>kie-dmn-core</artifactId>

--- a/ftl-transform-wih/pom.xml
+++ b/ftl-transform-wih/pom.xml
@@ -67,7 +67,7 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
+		<!--dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-utilities</artifactId>
 			<exclusions>
@@ -76,7 +76,7 @@
    			 		<artifactId>commons-codec</artifactId>
 				</exclusion>
 			</exclusions>
-		</dependency>
+		</dependency-->
 		<dependency>
 			<groupId>org.kie</groupId>
 			<artifactId>kie-dmn-core</artifactId>

--- a/generic-helpers/pom.xml
+++ b/generic-helpers/pom.xml
@@ -23,7 +23,7 @@
 		<version>0.0.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>generic-helpers</artifactId>
-	<version>0.0.3</version>
+	<version>0.0.4</version>
 	<name>Base helpers for the Generic services</name>
 	<description>Contains WIHInvoker</description>
 

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -286,52 +286,6 @@
 			<groupId>org.drools</groupId>
 			<artifactId>drools-decisiontables</artifactId>
 		</dependency>
-		<!--dependency>
-			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>hapi-fhir-structures-dstu2</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>hapi-fhir-structures-dstu3</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-codec</groupId>
-   			 		<artifactId>commons-codec</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>hapi-fhir-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>hapi-fhir-base</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-codec</groupId>
-   			 		<artifactId>commons-codec</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-    					<artifactId>slf4j-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-    					<artifactId>jcl-over-slf4j</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>hapi-fhir-utilities</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-codec</groupId>
-   			 		<artifactId>commons-codec</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r4</artifactId>
-			<version>3.8.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -283,7 +282,7 @@
 			<groupId>org.drools</groupId>
 			<artifactId>drools-decisiontables</artifactId>
 		</dependency>
-		<dependency>
+		<!--dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-dstu2</artifactId>
 		</dependency>
@@ -328,7 +327,7 @@
    			 		<artifactId>commons-codec</artifactId>
 				</exclusion>
 			</exclusions>
-		</dependency>
+		</dependency-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>

--- a/oauth-helpers/pom.xml
+++ b/oauth-helpers/pom.xml
@@ -27,7 +27,7 @@
 	</parent>
 
 	<artifactId>oauth-helpers</artifactId>
-	<version>0.0.6</version>
+	<version>0.0.7</version>
 	<description>OAuth Helper</description>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -483,25 +483,4 @@
 			</plugin>
 		</plugins>
 	</reporting>
-	<profiles>
-  <profile>
-    <id>owasp-dependency-check</id>
-    <build>
-      <plugins>
-        <plugin>
-          <groupId>org.owasp</groupId>
-          <artifactId>dependency-check-maven</artifactId>
-          <version>6.2.2</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </build>
-  </profile>
-</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<jackson.version>2.12.3</jackson.version>
 		<mockito.version>2.23.0</mockito.version>
 		<jedis.version>3.2.0</jedis.version>
-		<cds.helper.version>0.0.6</cds.helper.version>
+		<cds.helper.version>0.0.7</cds.helper.version>
 		<freemarker.version>2.3.30</freemarker.version>
 		<jacoco.version>0.8.3</jacoco.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
@@ -90,7 +90,7 @@
 			<dependency>
 				<groupId>${project.groupId}</groupId>
 				<artifactId>generic-helpers</artifactId>
-				<version>0.0.3</version>
+				<version>0.0.4</version>
 			</dependency>
 			<dependency>
 				<groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,13 @@
 		<kie.version>7.50.0.Final</kie.version>
 		<wb.kie.version>7.50.0.Final</wb.kie.version>
 		<junit.version>4.13.2</junit.version>
-		<hapi.fhir.version>3.8.0</hapi.fhir.version>
+		<hapi.fhir.version>5.6.0</hapi.fhir.version>
+		<hapi.fhir.utilities.version>5.5.7</hapi.fhir.utilities.version>
 		<json-simple.version>1.1.1</json-simple.version>
 		<h2.version>1.4.193</h2.version>
 		<hibernate.version>5.4.24.Final</hibernate.version>
 		<spring.boot.starter.version>2.4.8</spring.boot.starter.version>
-		<jackson.version>2.9.10.8</jackson.version>
+		<jackson.version>2.12.3</jackson.version>
 		<mockito.version>2.23.0</mockito.version>
 		<jedis.version>3.2.0</jedis.version>
 		<cds.helper.version>0.0.6</cds.helper.version>
@@ -27,6 +28,7 @@
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<httpclient.version>4.5.13</httpclient.version>
 		<httpcore.version>4.4.13</httpcore.version>
+		<gson.version>2.8.5</gson.version>
 	</properties>
 
 	<modules>
@@ -217,9 +219,29 @@
 				<version>${jackson.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-core</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-annotations</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.datatype</groupId>
+				<artifactId>jackson-datatype-jsr310</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>com.googlecode.json-simple</groupId>
 				<artifactId>json-simple</artifactId>
 				<version>${json-simple.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.google.code.gson</groupId>
+				<artifactId>gson</artifactId>
+				<version>${gson.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>junit</groupId>
@@ -266,7 +288,7 @@
 			<dependency>
 				<groupId>ca.uhn.hapi.fhir</groupId>
 				<artifactId>hapi-fhir-utilities</artifactId>
-				<version>${hapi.fhir.version}</version>
+				<version>${hapi.fhir.utilities.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
@@ -307,6 +329,16 @@
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
 				<version>3.6</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>2.8.0</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-codec</groupId>
+				<artifactId>commons-codec</artifactId>
+				<version>1.15</version>
 			</dependency>
 			<dependency>
 				<groupId>org.quartz-scheduler</groupId>
@@ -451,4 +483,25 @@
 			</plugin>
 		</plugins>
 	</reporting>
+	<profiles>
+  <profile>
+    <id>owasp-dependency-check</id>
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.owasp</groupId>
+          <artifactId>dependency-check-maven</artifactId>
+          <version>6.2.2</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+  </profile>
+</profiles>
 </project>

--- a/sms-wih/pom.xml
+++ b/sms-wih/pom.xml
@@ -87,7 +87,6 @@
 		<dependency>
     			<groupId>com.fasterxml.jackson.core</groupId>
     			<artifactId>jackson-annotations</artifactId>
-    			<version>2.10.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
@@ -97,7 +96,6 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
     			<artifactId>jackson-core</artifactId>
-    			<version>2.10.4</version>
 		</dependency>
 	</dependencies>
 	<parent>

--- a/task-utilities/pom.xml
+++ b/task-utilities/pom.xml
@@ -12,7 +12,7 @@
 
 	<properties>
 		<kie.version>7.50.0.Final</kie.version>
-		<hapi.version>3.8.0</hapi.version>
+		<hapi.version>5.6.0</hapi.version>
 		<freemarker.version>2.3.30</freemarker.version>
 	</properties>
 


### PR DESCRIPTION
Updated hapi-fhir dependencies to version 5.6.0 (components) and 5.5.7 (internal utilities)