### PR TITLE
Mitigate log4j api 2.17.0 vulnerability to 2.17.1

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -42,7 +42,7 @@
 		<spring.version>5.3.13</spring.version>
 		<resteasy-client.version>4.7.2.Final</resteasy-client.version>
 		<tomcat-embed-core.version>9.0.54</tomcat-embed-core.version>
-		<log4j.version>2.17.0</log4j.version>
+		<log4j.version>2.17.1</log4j.version>
 	</properties>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<httpcore.version>4.4.13</httpcore.version>
 		<gson.version>2.8.5</gson.version>
 		<maven.version>3.8.4</maven.version>
-		<log4j.version>2.17.0</log4j.version>
+		<log4j.version>2.17.1</log4j.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
Done with mitigate log4j-api vulnerability to 2.17.1.
Done with build and run test cases on local
![mitigate-log4j-api-2-17 0](https://user-images.githubusercontent.com/94971091/148547475-d4f76759-7e84-4de7-94f7-8f3ed9be3d4f.png)

