### PR TITLE
Fixed vulnerability for jackson databind by updating kie version

### DIFF
--- a/task-utilities/pom.xml
+++ b/task-utilities/pom.xml
@@ -11,7 +11,7 @@
 	<description>Task Utilities</description>
 
 	<properties>
-		<kie.version>7.50.0.Final</kie.version>
+		<kie.version>7.63.0.Final</kie.version>
 		<hapi.version>5.6.0</hapi.version>
 		<freemarker.version>2.3.30</freemarker.version>
 		<maven.version>3.8.4</maven.version>


### PR DESCRIPTION
old version of **jackson-databind@2.10.4** was comming thorugh org.jbpm:jbpm-human-task-core
updating kie version mitigated vulnerability for jackson-databind.

Tested locally by running unit test case and executed API.