### PR TITLE
Update of fhir-query-helper versions to 0.0.8

### DIFF
--- a/fhir-query-helper-base/pom.xml
+++ b/fhir-query-helper-base/pom.xml
@@ -27,7 +27,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-base</artifactId>
-	<version>0.0.7</version>
+	<version>0.0.8</version>
 	<description>CDS Helper base</description>
 
 	<properties>

--- a/fhir-query-helper-dstu2/pom.xml
+++ b/fhir-query-helper-dstu2/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-dstu2</artifactId>
-	<version>0.0.7</version>
+	<version>0.0.8</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper</description>
 

--- a/fhir-query-helper-dstu3/pom.xml
+++ b/fhir-query-helper-dstu3/pom.xml
@@ -26,7 +26,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-dstu3</artifactId>
-	<version>0.0.7</version>
+	<version>0.0.8</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper DSTU3</description>
 

--- a/fhir-query-helper-r4/pom.xml
+++ b/fhir-query-helper-r4/pom.xml
@@ -26,7 +26,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-r4</artifactId>
-	<version>0.0.7</version>
+	<version>0.0.8</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper R4</description>
 

--- a/oauth-helpers/pom.xml
+++ b/oauth-helpers/pom.xml
@@ -27,7 +27,7 @@
 	</parent>
 
 	<artifactId>oauth-helpers</artifactId>
-	<version>0.0.7</version>
+	<version>0.0.8</version>
 	<description>OAuth Helper</description>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<jackson.version>2.12.3</jackson.version>
 		<mockito.version>2.23.0</mockito.version>
 		<jedis.version>4.0.1</jedis.version>
-		<cds.helper.version>0.0.7</cds.helper.version>
+		<cds.helper.version>0.0.8</cds.helper.version>
 		<freemarker.version>2.3.30</freemarker.version>
 		<jacoco.version>0.8.7</jacoco.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>


### PR DESCRIPTION
In order for services to have a non-dependency to old jedis version 