### PR TITLE
Gt 672

### DIFF
--- a/cds-hook-model/src/main/java/io/elimu/a2d2/serviceapi/performance/PerformanceHelper.java
+++ b/cds-hook-model/src/main/java/io/elimu/a2d2/serviceapi/performance/PerformanceHelper.java
@@ -44,7 +44,8 @@ public class PerformanceHelper {
     	} catch (Throwable e) { /* make sure nothing fails because of Performance measurements*/ }
     }
 
-    public void endClock(String moduleName, String methodCalled) {
+    public long endClock(String moduleName, String methodCalled) {
+    	long delta = -1;
     	try {
     		if(perfomanceDebugEnabled){
     			long end = System.currentTimeMillis();
@@ -58,7 +59,7 @@ public class PerformanceHelper {
     				//to determine where the error might be in the code
     				addTrace(moduleName, methodCalled);
     			} else {
-    				long delta = end - start.longValue();
+    				delta = end - start.longValue();
     				if(delta > 5000){
     					LOGGER.info("!!MORE THAN 5 SECONDS " + threadName + ": " + key + " - " + delta + "ms");
     				}else{
@@ -67,6 +68,7 @@ public class PerformanceHelper {
     			}
     		}
         } catch (Throwable e) { /* make sure nothing fails because of Performance measurements*/ }
+    	return delta;
     }
 
 	private void addTrace(String moduleName, String methodCalled) {

--- a/cds-hook-model/src/main/java/io/elimu/a2d2/serviceapi/performance/PerformanceHelper.java
+++ b/cds-hook-model/src/main/java/io/elimu/a2d2/serviceapi/performance/PerformanceHelper.java
@@ -44,7 +44,11 @@ public class PerformanceHelper {
     	} catch (Throwable e) { /* make sure nothing fails because of Performance measurements*/ }
     }
 
-    public long endClock(String moduleName, String methodCalled) {
+    public void endClock(String moduleName, String methodCalled) {
+    	endClockRetTime(moduleName, methodCalled);
+    }
+
+	public long endClockRetTime(String moduleName, String methodCalled) {
     	long delta = -1;
     	try {
     		if(perfomanceDebugEnabled){
@@ -69,7 +73,7 @@ public class PerformanceHelper {
     		}
         } catch (Throwable e) { /* make sure nothing fails because of Performance measurements*/ }
     	return delta;
-    }
+	}
 
 	private void addTrace(String moduleName, String methodCalled) {
 		try {

--- a/core-wih/pom.xml
+++ b/core-wih/pom.xml
@@ -19,6 +19,11 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
+	<parent>
+		<groupId>io.elimu.a2d2</groupId>
+		<artifactId>parent</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
 	<artifactId>core-wih</artifactId>
 	<packaging>jar</packaging>
 
@@ -119,22 +124,5 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<!--dependency>
-			<groupId>io.elimu.a2d2</groupId>
-			<artifactId>fhir-query-helper-dstu2</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.elimu.a2d2</groupId>
-			<artifactId>fhir-query-helper-dstu3</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.elimu.a2d2</groupId>
-			<artifactId>fhir-query-helper-r4</artifactId>
-		</dependency-->
 	</dependencies>
-	<parent>
-		<groupId>io.elimu.a2d2</groupId>
-		<artifactId>parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-	</parent>
 </project>

--- a/core-wih/pom.xml
+++ b/core-wih/pom.xml
@@ -31,6 +31,20 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>com.mixpanel</groupId>
+			<artifactId>mixpanel-java</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.json</groupId>
+					<artifactId>json</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/core-wih/pom.xml
+++ b/core-wih/pom.xml
@@ -31,6 +31,8 @@
 	<url>http://maven.apache.org</url>
 
 	<properties>
+		<mixpanel.version>1.4.4</mixpanel.version>
+		<org.json.version>20211205</org.json.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 

--- a/core-wih/pom.xml
+++ b/core-wih/pom.xml
@@ -33,6 +33,7 @@
 		<dependency>
 			<groupId>com.mixpanel</groupId>
 			<artifactId>mixpanel-java</artifactId>
+			<version>${mixpanel.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.json</groupId>
@@ -43,6 +44,7 @@
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
+			<version>${org.json.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/core-wih/src/main/java/io/elimu/a2d2/corewih/MixPanelWorkItemHandler.java
+++ b/core-wih/src/main/java/io/elimu/a2d2/corewih/MixPanelWorkItemHandler.java
@@ -1,0 +1,56 @@
+package io.elimu.a2d2.corewih;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.json.JSONObject;
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.runtime.process.WorkItemHandler;
+import org.kie.api.runtime.process.WorkItemManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mixpanel.mixpanelapi.MessageBuilder;
+import com.mixpanel.mixpanelapi.MixpanelAPI;
+
+public class MixPanelWorkItemHandler implements WorkItemHandler {
+
+	private static final Logger LOG = LoggerFactory.getLogger(MixPanelWorkItemHandler.class);
+	public static final String MIXPANEL_PREFIX = "mixpanel_";
+	
+	@Override
+	public void executeWorkItem(WorkItem workItem, WorkItemManager manager) {
+		String appToken = System.getProperty("mixpanel.app.token");
+		if (appToken == null) {
+			LOG.info("No mixpannel app token provided in the system config. Returning without sending event");
+			manager.completeWorkItem(workItem.getId(), workItem.getResults());
+			return;
+		}
+		String evtName = (String) workItem.getParameter("eventDescription");
+		if (evtName == null || "".equals(evtName.trim())) {
+			evtName = "Omnibus Generic Event";
+		}
+		JSONObject evt = new JSONObject();
+		for (String key : workItem.getParameters().keySet()) {
+			if (key.startsWith(MIXPANEL_PREFIX)) {
+				evt.put(key.replace(MIXPANEL_PREFIX, ""), workItem.getParameter(key));
+			}
+		}
+		MessageBuilder messageBuilder = new MessageBuilder(appToken);
+		JSONObject omnibusEvent = messageBuilder.event(UUID.randomUUID().toString(), evtName, evt);
+		MixpanelAPI mixpanel = new MixpanelAPI();
+		try {
+			mixpanel.sendMessage(omnibusEvent);
+			LOG.debug("Sending single mixpanel event");
+			manager.completeWorkItem(workItem.getId(), workItem.getResults());
+		} catch (IOException e) {
+			LOG.error("Could not send event to mixpanel", e);
+			manager.abortWorkItem(workItem.getId());
+		}
+	}
+
+	@Override
+	public void abortWorkItem(WorkItem workItem, WorkItemManager manager) {
+		// do nothing
+	}
+}

--- a/core-wih/src/main/java/io/elimu/a2d2/corewih/MixPanelWorkItemHandler.java
+++ b/core-wih/src/main/java/io/elimu/a2d2/corewih/MixPanelWorkItemHandler.java
@@ -1,7 +1,6 @@
 package io.elimu.a2d2.corewih;
 
 import java.io.IOException;
-import java.util.UUID;
 
 import org.json.JSONObject;
 import org.kie.api.runtime.process.WorkItem;
@@ -21,8 +20,9 @@ public class MixPanelWorkItemHandler implements WorkItemHandler {
 	@Override
 	public void executeWorkItem(WorkItem workItem, WorkItemManager manager) {
 		String appToken = System.getProperty("mixpanel.app.token");
-		if (appToken == null) {
-			LOG.info("No mixpannel app token provided in the system config. Returning without sending event");
+		String distinctId = System.getProperty("mixpanel.app.name");
+		if (appToken == null || distinctId == null) {
+			LOG.info("No mixpannel app token or name provided in the system config. Returning without sending event");
 			manager.completeWorkItem(workItem.getId(), workItem.getResults());
 			return;
 		}
@@ -37,7 +37,7 @@ public class MixPanelWorkItemHandler implements WorkItemHandler {
 			}
 		}
 		MessageBuilder messageBuilder = new MessageBuilder(appToken);
-		JSONObject omnibusEvent = messageBuilder.event(UUID.randomUUID().toString(), evtName, evt);
+		JSONObject omnibusEvent = messageBuilder.event(distinctId, evtName, evt);
 		MixpanelAPI mixpanel = new MixpanelAPI();
 		try {
 			mixpanel.sendMessage(omnibusEvent);

--- a/core-wih/src/main/java/io/elimu/a2d2/corewih/MixPanelWorkItemHandler.java
+++ b/core-wih/src/main/java/io/elimu/a2d2/corewih/MixPanelWorkItemHandler.java
@@ -20,9 +20,9 @@ public class MixPanelWorkItemHandler implements WorkItemHandler {
 	@Override
 	public void executeWorkItem(WorkItem workItem, WorkItemManager manager) {
 		String appToken = System.getProperty("mixpanel.app.token");
-		String distinctId = System.getProperty("mixpanel.app.name");
+		String distinctId = (String) workItem.getParameter("distinctId");
 		if (appToken == null || distinctId == null) {
-			LOG.info("No mixpannel app token or name provided in the system config. Returning without sending event");
+			LOG.info("No mixpannel app token or distinct ID provided. Returning without sending event");
 			manager.completeWorkItem(workItem.getId(), workItem.getResults());
 			return;
 		}

--- a/core-wih/src/test/java/io/elimu/a2d2/core_wih/MixPanelWIHTest.java
+++ b/core-wih/src/test/java/io/elimu/a2d2/core_wih/MixPanelWIHTest.java
@@ -1,0 +1,55 @@
+package io.elimu.a2d2.core_wih;
+
+import java.util.Map;
+
+import org.drools.core.process.instance.impl.WorkItemImpl;
+import org.junit.Assert;
+import org.junit.Test;
+import org.kie.api.runtime.process.WorkItemHandler;
+import org.kie.api.runtime.process.WorkItemManager;
+
+import io.elimu.a2d2.corewih.MixPanelWorkItemHandler;
+
+public class MixPanelWIHTest {
+
+	@Test
+	public void testMixPanelEvent() {
+		MixPanelWorkItemHandler handler = new MixPanelWorkItemHandler();
+		if (System.getProperty("mixpanel.app.token") == null) {
+			return;
+		}
+		WorkItemImpl workItem = new WorkItemImpl();
+		workItem.setParameter("eventDescription", "My Test Event");
+		workItem.setParameter("mixpanel_info", "Some value");
+		workItem.setParameter("mixpanel_otherInfo", "Something else");
+		NoOpWorkItemManager manager = new NoOpWorkItemManager();
+		handler.executeWorkItem(workItem, manager);
+		Assert.assertEquals("completed", manager.getStatus());
+	}
+	
+	class NoOpWorkItemManager implements WorkItemManager {
+
+		private String status;
+		
+		public String getStatus() {
+			return status;
+		}
+		
+		@Override
+		public void completeWorkItem(long id, Map<String, Object> results) {
+			status = "completed";
+		}
+
+		@Override
+		public void abortWorkItem(long id) {
+			status = "aborted";
+		}
+
+		@Override
+		public void registerWorkItemHandler(String workItemName, WorkItemHandler handler) {
+			// TODO Auto-generated method stub
+			
+		}
+		
+	}
+}

--- a/generic-helpers/pom.xml
+++ b/generic-helpers/pom.xml
@@ -24,7 +24,7 @@
 		<relativePath/>
 	</parent>
 	<artifactId>generic-helpers</artifactId>
-	<version>0.0.4</version>
+	<version>0.0.5</version>
 	<name>Base helpers for the Generic services</name>
 	<description>Contains WIHInvoker</description>
 

--- a/generic-helpers/src/main/java/io/elimu/a2d2/helpers/MixPanelService.java
+++ b/generic-helpers/src/main/java/io/elimu/a2d2/helpers/MixPanelService.java
@@ -1,0 +1,32 @@
+package io.elimu.a2d2.helpers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.drools.core.spi.KnowledgeHelper;
+
+public class MixPanelService {
+	private static final MixPanelService INSTANCE = new MixPanelService();
+
+	private MixPanelService() {
+	}
+
+	public static MixPanelService getInstance() {
+		return INSTANCE;
+	}
+
+	public void track(KnowledgeHelper drools, String eventName, Map<String, Object> action) {
+		Map<String, Object> parameters = new HashMap<String, Object>();
+		parameters.put("eventDescription", eventName);
+		if (action != null) {
+			for (String key : action.keySet()) {
+				parameters.put("mixpanel_" + key, action.get(key));
+			}
+		}
+		WIHInvoker.invoke(drools, "MixPanelInvocation", parameters);
+	}
+
+	public String hashPatient(String value) {
+		return value;//TODO once java-commons has the hash value, it has to be used from here
+	}
+}

--- a/generic-helpers/src/main/java/io/elimu/a2d2/helpers/MixPanelService.java
+++ b/generic-helpers/src/main/java/io/elimu/a2d2/helpers/MixPanelService.java
@@ -1,5 +1,8 @@
 package io.elimu.a2d2.helpers;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,7 +29,23 @@ public class MixPanelService {
 		WIHInvoker.invoke(drools, "MixPanelInvocation", parameters);
 	}
 
-	public String hashPatient(String value) {
-		return value;//TODO once java-commons has the hash value, it has to be used from here
+	public String hashPatient(String value) throws NoSuchAlgorithmException {
+		String salt = System.getenv("SALT"); // this needs to be added to the task definition
+		if (salt == null) {
+			salt = "";
+		}
+		byte[] hashBytes = MessageDigest.getInstance("SHA-256").digest((value + salt).getBytes(StandardCharsets.UTF_8));
+		return bytesToHex(hashBytes);
 	}
+	
+	 private String bytesToHex(byte[] hash) {
+		 StringBuilder hexString = new StringBuilder(2 * hash.length);
+		 for (byte h : hash) {
+			 String hex = Integer.toHexString(0xff & h);
+			 if (hex.length() == 1)
+				 hexString.append('0');
+			 hexString.append(hex);
+		 }
+		 return hexString.toString();
+	 }
 }

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -20,6 +20,10 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>com.mixpanel</groupId>
+			<artifactId>mixpanel-java</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r4</artifactId>
 			<scope>test</scope>

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -22,6 +22,7 @@
 		<dependency>
 			<groupId>com.mixpanel</groupId>
 			<artifactId>mixpanel-java</artifactId>
+			<version>${mixpanel.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.json</groupId>
@@ -32,6 +33,7 @@
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
+			<version>${org.json.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -22,6 +22,16 @@
 		<dependency>
 			<groupId>com.mixpanel</groupId>
 			<artifactId>mixpanel-java</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.json</groupId>
+					<artifactId>json</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -16,6 +16,8 @@
 
 	<properties>
 		<cxf.version>3.4.5</cxf.version>
+		<mixpanel.version>1.4.4</mixpanel.version>
+		<org.json.version>20211205</org.json.version>
 	</properties>
 
 	<dependencies>

--- a/kie-based-services/src/main/java/io/elimu/genericapi/service/GenericKieBasedService.java
+++ b/kie-based-services/src/main/java/io/elimu/genericapi/service/GenericKieBasedService.java
@@ -23,6 +23,9 @@ import org.drools.persistence.PersistableRunner;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
+import org.kie.api.event.process.ProcessEventListener;
+import org.kie.api.event.rule.AgendaEventListener;
+import org.kie.api.event.rule.RuleRuntimeEventListener;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.process.WorkflowProcessInstance;
@@ -132,6 +135,7 @@ public class GenericKieBasedService extends AbstractKieService implements Generi
 			runtime = getManager().getRuntimeEngine(ProcessInstanceIdContext.get());
 			KieSession ksession = runtime.getKieSession();
 			GenericDebugListener listener = enableDebugging(ksession, request);
+			enableMixpanel(ksession);
 			String procId = getProcessId(request.getMethod());
 			if (procId != null && !NOT_ALLOWED_METHOD_KEY.equals(procId)) {
 				LOG.info("Executing process " + procId + " for service " + getId());
@@ -182,6 +186,13 @@ public class GenericKieBasedService extends AbstractKieService implements Generi
 		return body;
 	}
 
+	private void enableMixpanel(KieSession ksession) {
+		MixPanelEventListener listener = new MixPanelEventListener(getConfig());
+		ksession.addEventListener((AgendaEventListener) listener);
+		ksession.addEventListener((ProcessEventListener) listener);
+		ksession.addEventListener((RuleRuntimeEventListener) listener);
+	}
+	
 	private GenericDebugListener enableDebugging(KieSession ksession, ServiceRequest request) {
 		String defaultEnabled = System.getProperty("service.debug.enabled", "false");
 		String header = request.getHeader("x-enable-debug");

--- a/kie-based-services/src/main/java/io/elimu/genericapi/service/MixPanelEventListener.java
+++ b/kie-based-services/src/main/java/io/elimu/genericapi/service/MixPanelEventListener.java
@@ -116,9 +116,10 @@ public class MixPanelEventListener implements ProcessEventListener, RuleRuntimeE
 
 	@Override
 	public void beforeProcessStarted(ProcessStartedEvent event) {
-		if (serviceConfig.containsKey("mixpanel.log") && serviceConfig.getProperty("mixpanel.log").contains("process.start")) {
+		if (serviceConfig.containsKey("mixpanel.log") && serviceConfig.getProperty("mixpanel.log").contains("process." + event.getProcessInstance().getProcessId() + ".start")) {
 			try {
 				JSONObject evt = new JSONObject();
+				evt.put("eventDescription", "Process " + event.getProcessInstance().getProcessId() + " completed");
 				evt.put("eventType", ("beforeProcessStarted"));
 				evt.put("processId", (event.getProcessInstance().getProcessId()));
 				evt.put("processInstanceId", (event.getProcessInstance().getId()));
@@ -139,9 +140,10 @@ public class MixPanelEventListener implements ProcessEventListener, RuleRuntimeE
 
 	@Override
 	public void afterProcessCompleted(ProcessCompletedEvent event) {
-		if (serviceConfig.containsKey("mixpanel.log") && serviceConfig.getProperty("mixpanel.log").contains("process.end")) {
+		if (serviceConfig.containsKey("mixpanel.log") && serviceConfig.getProperty("mixpanel.log").contains("process." + event.getProcessInstance().getProcessId() +  ".end")) {
 			try {
 				JSONObject evt = new JSONObject();
+				evt.put("eventDescription", "Process " + event.getProcessInstance().getProcessId() + " completed");
 				evt.put("eventType", ("afterProcessCompleted"));
 				evt.put("processId", (event.getProcessInstance().getProcessId()));
 				evt.put("processInstanceId", (event.getProcessInstance().getId()));
@@ -158,6 +160,7 @@ public class MixPanelEventListener implements ProcessEventListener, RuleRuntimeE
 			try {
 				JSONObject evt = new JSONObject();
 				evt.put("eventType", ("beforeNodeTriggered"));
+				evt.put("eventDescription", "Process " + event.getProcessInstance().getProcessId() + " node of type " + event.getNodeInstance().getNodeName() + " triggered");
 				evt.put("processId", (event.getProcessInstance().getProcessId()));
 				evt.put("processInstanceId", (event.getProcessInstance().getId()));
 				if (event.getNodeInstance() != null && event.getNodeInstance().getNodeName() != null) {
@@ -183,6 +186,7 @@ public class MixPanelEventListener implements ProcessEventListener, RuleRuntimeE
 		if (serviceConfig.containsKey("mixpanel.log") && serviceConfig.getProperty("mixpanel.log").contains("process.node." + event.getNodeInstance().getNodeName() + ".left")) {
 			try {
 				JSONObject evt = new JSONObject();
+				evt.put("eventDescription", "Process " + event.getProcessInstance().getProcessId() + " node of type " + event.getNodeInstance().getNodeName() + " completed");
 				evt.put("eventType", ("afterNodeLeft"));
 				evt.put("processId", (event.getProcessInstance().getProcessId()));
 				evt.put("processInstanceId", (event.getProcessInstance().getId()));
@@ -205,6 +209,7 @@ public class MixPanelEventListener implements ProcessEventListener, RuleRuntimeE
 		if (serviceConfig.containsKey("mixpanel.log") && serviceConfig.getProperty("mixpanel.log").contains("process.var." + event.getVariableId() + ".change")) {
 			try {
 				JSONObject evt = new JSONObject();
+				evt.put("eventDescription", "Process " + event.getProcessInstance().getProcessId() + " variable " + event.getVariableId() + " changed");
 				evt.put("eventType", ("afterVariableChanged"));
 				evt.put("processId", (event.getProcessInstance().getProcessId()));
 				evt.put("processInstanceId", (event.getProcessInstance().getId()));

--- a/kie-based-services/src/main/java/io/elimu/genericapi/service/MixPanelEventListener.java
+++ b/kie-based-services/src/main/java/io/elimu/genericapi/service/MixPanelEventListener.java
@@ -1,0 +1,238 @@
+package io.elimu.genericapi.service;
+
+import java.util.Properties;
+import java.util.regex.Pattern;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.kie.api.event.process.ProcessCompletedEvent;
+import org.kie.api.event.process.ProcessEventListener;
+import org.kie.api.event.process.ProcessNodeLeftEvent;
+import org.kie.api.event.process.ProcessNodeTriggeredEvent;
+import org.kie.api.event.process.ProcessStartedEvent;
+import org.kie.api.event.process.ProcessVariableChangedEvent;
+import org.kie.api.event.rule.AfterMatchFiredEvent;
+import org.kie.api.event.rule.AgendaEventListener;
+import org.kie.api.event.rule.AgendaGroupPoppedEvent;
+import org.kie.api.event.rule.AgendaGroupPushedEvent;
+import org.kie.api.event.rule.BeforeMatchFiredEvent;
+import org.kie.api.event.rule.MatchCancelledEvent;
+import org.kie.api.event.rule.MatchCreatedEvent;
+import org.kie.api.event.rule.ObjectDeletedEvent;
+import org.kie.api.event.rule.ObjectInsertedEvent;
+import org.kie.api.event.rule.ObjectUpdatedEvent;
+import org.kie.api.event.rule.RuleFlowGroupActivatedEvent;
+import org.kie.api.event.rule.RuleFlowGroupDeactivatedEvent;
+import org.kie.api.event.rule.RuleRuntimeEventListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Considering keys
+ * 
+ * mixpanel.log=process.start,process.end,process.var.varName.change,process.node.nodeName.trigger,process.node.nodeName.left,rules.ruleName.fire
+ *
+ */
+public class MixPanelEventListener implements ProcessEventListener, RuleRuntimeEventListener, AgendaEventListener {
+
+	private static final Logger LOG = LoggerFactory.getLogger(MixPanelEventListener.class);
+	private final Properties serviceConfig;
+	
+	public MixPanelEventListener(Properties config) {
+		this.serviceConfig = config;
+	}
+	
+	protected void process(JSONObject event) {
+		MixPanelStack.getInstance().add(event);
+	}
+	
+	@Override
+	public void matchCreated(MatchCreatedEvent event) {
+	}
+
+	@Override
+	public void matchCancelled(MatchCancelledEvent event) {
+	}
+
+	@Override
+	public void beforeMatchFired(BeforeMatchFiredEvent event) {
+	}
+
+	@Override
+	public void afterMatchFired(AfterMatchFiredEvent event) {
+		if (serviceConfig.containsKey("mixpanel.log") && serviceConfig.getProperty("mixpanel.log").contains("rules." + event.getMatch().getRule().getName() + ".fire")) {
+			try {
+				JSONObject evt = new JSONObject();
+				evt.put("eventType", ("afterMatchFired"));
+				evt.put("ruleName", (event.getMatch().getRule().getName()));
+				JSONArray array = new JSONArray();
+				for (Object obj : event.getMatch().getObjects()) {
+					array.put(hidePasswordValue(obj));
+				}
+				evt.put("objects", array);
+				process(evt);
+			} catch (JSONException e) {
+				LOG.warn("problem creating MixPanel event data", e);
+			}
+		}
+	}
+
+	@Override
+	public void agendaGroupPopped(AgendaGroupPoppedEvent event) {
+	}
+
+	@Override
+	public void agendaGroupPushed(AgendaGroupPushedEvent event) {
+	}
+
+	@Override
+	public void beforeRuleFlowGroupActivated(RuleFlowGroupActivatedEvent event) {
+	}
+
+	@Override
+	public void afterRuleFlowGroupActivated(RuleFlowGroupActivatedEvent event) {
+	}
+
+	@Override
+	public void beforeRuleFlowGroupDeactivated(RuleFlowGroupDeactivatedEvent event) {
+	}
+
+	@Override
+	public void afterRuleFlowGroupDeactivated(RuleFlowGroupDeactivatedEvent event) {
+	}
+
+	@Override
+	public void objectInserted(ObjectInsertedEvent event) {
+	}
+
+	@Override
+	public void objectUpdated(ObjectUpdatedEvent event) {
+	}
+
+	@Override
+	public void objectDeleted(ObjectDeletedEvent event) {
+	}
+
+	@Override
+	public void beforeProcessStarted(ProcessStartedEvent event) {
+		if (serviceConfig.containsKey("mixpanel.log") && serviceConfig.getProperty("mixpanel.log").contains("process.start")) {
+			try {
+				JSONObject evt = new JSONObject();
+				evt.put("eventType", ("beforeProcessStarted"));
+				evt.put("processId", (event.getProcessInstance().getProcessId()));
+				evt.put("processInstanceId", (event.getProcessInstance().getId()));
+				process(evt);
+			} catch (JSONException e) {
+				LOG.warn("problem creating MixPanel event data", e);
+			}
+		}
+	}
+
+	@Override
+	public void afterProcessStarted(ProcessStartedEvent event) {
+	}
+
+	@Override
+	public void beforeProcessCompleted(ProcessCompletedEvent event) {
+	}
+
+	@Override
+	public void afterProcessCompleted(ProcessCompletedEvent event) {
+		if (serviceConfig.containsKey("mixpanel.log") && serviceConfig.getProperty("mixpanel.log").contains("process.end")) {
+			try {
+				JSONObject evt = new JSONObject();
+				evt.put("eventType", ("afterProcessCompleted"));
+				evt.put("processId", (event.getProcessInstance().getProcessId()));
+				evt.put("processInstanceId", (event.getProcessInstance().getId()));
+				process(evt);
+			} catch (JSONException e) {
+				LOG.warn("problem creating MixPanel event data", e);
+			}
+		}
+	}
+
+	@Override
+	public void beforeNodeTriggered(ProcessNodeTriggeredEvent event) {
+		if (serviceConfig.containsKey("mixpanel.log") && serviceConfig.getProperty("mixpanel.log").contains("process.node." + event.getNodeInstance().getNodeName() + ".trigger")) {
+			try {
+				JSONObject evt = new JSONObject();
+				evt.put("eventType", ("beforeNodeTriggered"));
+				evt.put("processId", (event.getProcessInstance().getProcessId()));
+				evt.put("processInstanceId", (event.getProcessInstance().getId()));
+				if (event.getNodeInstance() != null && event.getNodeInstance().getNodeName() != null) {
+					evt.put("nodeName", (event.getNodeInstance().getNodeName()));
+				}
+				process(evt);
+			} catch (JSONException e) {
+				LOG.warn("problem creating MixPanel event data", e);
+			}
+		}
+	}
+
+	@Override
+	public void afterNodeTriggered(ProcessNodeTriggeredEvent event) {
+	}
+
+	@Override
+	public void beforeNodeLeft(ProcessNodeLeftEvent event) {
+	}
+
+	@Override
+	public void afterNodeLeft(ProcessNodeLeftEvent event) {
+		if (serviceConfig.containsKey("mixpanel.log") && serviceConfig.getProperty("mixpanel.log").contains("process.node." + event.getNodeInstance().getNodeName() + ".left")) {
+			try {
+				JSONObject evt = new JSONObject();
+				evt.put("eventType", ("afterNodeLeft"));
+				evt.put("processId", (event.getProcessInstance().getProcessId()));
+				evt.put("processInstanceId", (event.getProcessInstance().getId()));
+				if (event.getNodeInstance() != null && event.getNodeInstance().getNodeName() != null) {
+					evt.put("nodeName", (event.getNodeInstance().getNodeName()));
+				}
+				process(evt);
+			} catch (JSONException e) {
+				LOG.warn("problem creating MixPanel event data", e);
+			}
+		}
+	}
+
+	@Override
+	public void beforeVariableChanged(ProcessVariableChangedEvent event) {
+	}
+
+	@Override
+	public void afterVariableChanged(ProcessVariableChangedEvent event) {
+		if (serviceConfig.containsKey("mixpanel.log") && serviceConfig.getProperty("mixpanel.log").contains("process.var." + event.getVariableId() + ".change")) {
+			try {
+				JSONObject evt = new JSONObject();
+				evt.put("eventType", ("afterVariableChanged"));
+				evt.put("processId", (event.getProcessInstance().getProcessId()));
+				evt.put("processInstanceId", (event.getProcessInstance().getId()));
+				evt.put("variableId", (event.getVariableId()));
+				if (event.getVariableId().toLowerCase().contains("password")) {
+					evt.put("oldValue", event.getOldValue() == null ? null : ("*******"));
+					evt.put("newValue", event.getNewValue() == null ? null : ("*******"));
+				} else {
+					evt.put("oldValue", event.getOldValue() == null ? null : (hidePasswordValue(event.getOldValue())));
+					evt.put("newValue", event.getNewValue() == null ? null : (hidePasswordValue(event.getNewValue())));
+				}
+				process(evt);
+			} catch (JSONException e) {
+				LOG.warn("problem creating MixPanel event data", e);
+			}
+		}
+	}
+
+	private static String hidePasswordValue(Object value) {
+		if (value == null) {
+			return "null";
+		}
+		String retval = value.toString();
+		//basically, any variable or attribute in the toString that has password is taken and stripped
+		if (retval.toLowerCase().contains("password")) {
+			Pattern pat = java.util.regex.Pattern.compile("assword([^=]*)=([^,\\\\])*");
+			retval = pat.matcher(retval).replaceAll("assword$1=-----");
+		}
+		return retval;
+	}
+}

--- a/kie-based-services/src/main/java/io/elimu/genericapi/service/MixPanelStack.java
+++ b/kie-based-services/src/main/java/io/elimu/genericapi/service/MixPanelStack.java
@@ -1,0 +1,82 @@
+package io.elimu.genericapi.service;
+
+import java.io.IOException;
+import java.util.Stack;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mixpanel.mixpanelapi.ClientDelivery;
+import com.mixpanel.mixpanelapi.MessageBuilder;
+import com.mixpanel.mixpanelapi.MixpanelAPI;
+
+public class MixPanelStack implements Runnable {
+
+	private static final MixPanelStack INSTANCE = new MixPanelStack();
+	private static final Logger LOG = LoggerFactory.getLogger(MixPanelStack.class);
+	
+	private final Stack<JSONObject> events = new Stack<>();
+
+	private String token;
+
+	private MixPanelStack() {
+		this.token = System.getProperty("mixpanel.app.token");
+		if (this.token == null || "".equals(this.token.trim())) {
+			LOG.warn("Implementation of mixpanel requires a mixpanel.app.token configured in the JVM properties. It will be disabled for now");
+			Thread thread = new Thread() {
+				@Override
+				public void run() {
+					while(true) {
+						try {
+							Thread.sleep(100);
+						} catch (InterruptedException e) {
+							return;
+						}
+						events.clear();
+					}
+				}
+			};
+			thread.start();
+		} else {
+			Thread thread = Executors.defaultThreadFactory().newThread(this);
+			thread.start();
+		}
+	}
+	
+	public static MixPanelStack getInstance() {
+		return INSTANCE;
+	}
+
+	public void add(JSONObject event) {
+		events.add(event);
+	}
+
+	@Override
+	public void run() {
+		while (true) {
+			if (events.empty()) {
+				try {
+					Thread.sleep(5000L);
+				} catch (InterruptedException e) {
+					return;
+				}
+				continue;
+			}
+			ClientDelivery delivery = new ClientDelivery();
+			MessageBuilder messageBuilder = new MessageBuilder(token);
+			while (!events.empty()) {
+				JSONObject omnibusEvent = messageBuilder.event(UUID.randomUUID().toString(), "omnibusEvent", events.pop());
+				delivery.addMessage(omnibusEvent);
+			}
+			MixpanelAPI mixpanel = new MixpanelAPI();
+			try {
+				mixpanel.deliver(delivery);
+			} catch (IOException e) {
+				LOG.error("Could not send events to mixpanel", e);
+			}
+		}
+	}
+}

--- a/kie-based-services/src/main/java/io/elimu/genericapi/service/MixPanelStack.java
+++ b/kie-based-services/src/main/java/io/elimu/genericapi/service/MixPanelStack.java
@@ -2,6 +2,7 @@ package io.elimu.genericapi.service;
 
 import java.io.IOException;
 import java.util.Stack;
+import java.util.UUID;
 import java.util.concurrent.Executors;
 
 import org.json.JSONException;
@@ -25,7 +26,6 @@ public class MixPanelStack implements Runnable {
 
 	private MixPanelStack() {
 		this.token = System.getProperty("mixpanel.app.token");
-		this.distinctId = System.getProperty("mixpanel.app.name");
 		if (this.token == null || "".equals(this.token.trim())) {
 			LOG.warn("Implementation of mixpanel requires a mixpanel.app.token configured in the JVM properties. It will be disabled for now");
 			Thread thread = new Thread() {
@@ -79,7 +79,10 @@ public class MixPanelStack implements Runnable {
 				if (evtName == null || "".equals(evtName.trim())) {
 					evtName = "Omnibus General Event";
 				}
-				
+				String distinctId = evt.getString("distinctId");
+				if (distinctId == null || "".equals(distinctId.trim())) {
+					distinctId = UUID.randomUUID().toString();
+				}
 				JSONObject omnibusEvent = messageBuilder.event(distinctId, evtName, evt);
 				delivery.addMessage(omnibusEvent);
 				count++;

--- a/kie-based-services/src/main/java/io/elimu/genericapi/service/MixPanelStack.java
+++ b/kie-based-services/src/main/java/io/elimu/genericapi/service/MixPanelStack.java
@@ -71,7 +71,11 @@ public class MixPanelStack implements Runnable {
 			int count = 0;
 			while (!events.empty()) {
 				JSONObject evt = events.pop();
-				JSONObject omnibusEvent = messageBuilder.event(UUID.randomUUID().toString(), evt.getString("eventDescription"), evt);
+				String evtName = evt.getString("eventDescription");
+				if (evtName == null || "".equals(evtName.trim())) {
+					evtName = "Omnibus General Event";
+				}
+				JSONObject omnibusEvent = messageBuilder.event(UUID.randomUUID().toString(), evtName, evt);
 				delivery.addMessage(omnibusEvent);
 				count++;
 			}
@@ -90,7 +94,7 @@ public class MixPanelStack implements Runnable {
 	public void registerTime(long timeInMillis, String serviceId) {
 		try {
 			JSONObject evt = new JSONObject();
-			evt.put("eventDescription", "Service " + serviceId + " invoked");
+			evt.put("eventDescription", "Omnibus Service " + serviceId + " invoked");
 			evt.put("eventType", ("Service Executed"));
 			evt.put("serviceName", serviceId);
 			evt.put("executionTime", timeInMillis);

--- a/kie-based-services/src/main/java/io/elimu/serviceapi/service/ConfigRegisterableItemsFactory.java
+++ b/kie-based-services/src/main/java/io/elimu/serviceapi/service/ConfigRegisterableItemsFactory.java
@@ -35,6 +35,8 @@ import org.mvel2.ParserContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.elimu.genericapi.service.MixPanelEventListener;
+
 public class ConfigRegisterableItemsFactory extends BasicRegisterableItemsFactory {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ConfigRegisterableItemsFactory.class);
@@ -42,12 +44,14 @@ public class ConfigRegisterableItemsFactory extends BasicRegisterableItemsFactor
 	private final Properties config;
 	private final String serviceId;
 	private final KieContainer kcontainer;
+	private MixPanelEventListener mixpanel;
 	
 	public ConfigRegisterableItemsFactory(KieContainer kcontainer, String serviceId, DeploymentDescriptor descriptor, boolean logExecution, Properties props) {
 		super(descriptor, logExecution);
 		this.kcontainer = kcontainer;
 		this.serviceId = serviceId;
 		this.config = props;
+		this.mixpanel = new MixPanelEventListener(props);
 	}
 
 	
@@ -108,6 +112,7 @@ public class ConfigRegisterableItemsFactory extends BasicRegisterableItemsFactor
 		if (logExecution) {
 			listeners.add(new DebugProcessEventListener());
 		}
+		listeners.add(mixpanel);
 		return listeners;
 	}
 	
@@ -178,6 +183,7 @@ public class ConfigRegisterableItemsFactory extends BasicRegisterableItemsFactor
 		if (logExecution) {
 			listeners.add(new DebugAgendaEventListener());
 		}
+		listeners.add(mixpanel);
 		return listeners;
 	}
 
@@ -187,6 +193,7 @@ public class ConfigRegisterableItemsFactory extends BasicRegisterableItemsFactor
 		if (logExecution) {
 			listeners.add(new DebugRuleRuntimeEventListener());
 		}
+		listeners.add(mixpanel);
 		return listeners;
 	}
 

--- a/kie-based-services/src/test/java/io/elimu/genericapi/service/MixPanelTest.java
+++ b/kie-based-services/src/test/java/io/elimu/genericapi/service/MixPanelTest.java
@@ -1,0 +1,57 @@
+package io.elimu.genericapi.service;
+
+import java.util.Date;
+import java.util.Properties;
+
+import org.jbpm.ruleflow.instance.RuleFlowProcessInstance;
+import org.junit.Test;
+import org.kie.api.event.process.ProcessStartedEvent;
+import org.kie.api.runtime.KieRuntime;
+import org.kie.api.runtime.process.ProcessInstance;
+
+public class MixPanelTest {
+
+	@Test
+	public void testMixPanelConnection() throws Exception {
+		if (System.getProperty("mixpanel.app.token") == null) {
+			return;
+		}
+		Properties config = new Properties();
+		config.setProperty("mixpanel.log", "process.test-process.start");
+		//for PP HTN, mixpanel.log in pp-htn-program should be like this:
+			//mixpanel.log=process.pp-htn-program-start,process.node.SMSSingleInteraction.trigger
+		//for pp-htn-formsubmit should be like this
+			//mixpanel.log=process.pp-htn-formsubmit.end
+		MixPanelEventListener listener = new MixPanelEventListener(config);
+		final ProcessInstance procInst = new RuleFlowProcessInstance() {
+			private static final long serialVersionUID = 1L;
+			@Override
+			public String getProcessId() {
+				return "test-process";
+			}
+			@Override
+			public long getId() {
+				return 33L;
+			}
+		};
+		ProcessStartedEvent evt = new ProcessStartedEvent() {
+			
+			@Override
+			public KieRuntime getKieRuntime() {
+				return null;
+			}
+			
+			@Override
+			public ProcessInstance getProcessInstance() {
+				return procInst;
+			}
+			
+			@Override
+			public Date getEventDate() {
+				return null;
+			}
+		};
+		listener.beforeProcessStarted(evt);
+		Thread.sleep(10000);//wait for messages to be consumed
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -68,16 +68,6 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>com.mixpanel</groupId>
-				<artifactId>mixpanel-java</artifactId>
-				<version>${mixpanel.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.json</groupId>
-				<artifactId>json</artifactId>
-				<version>${org.json.version}</version>
-			</dependency>
-			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-to-slf4j</artifactId>
 				<version>${log4j.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 		<junit-platform-commons.version>1.8.1</junit-platform-commons.version>
 		<apiguardian.version>1.1.2</apiguardian.version>
 		<netty.version>4.1.73.Final</netty.version>
+		<mixpanel.version>1.4.4</mixpanel.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
@@ -65,6 +66,11 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>com.mixpanel</groupId>
+				<artifactId>mixpanel-java</artifactId>
+				<version>${mixpanel.version}</version>
+			</dependency>
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-to-slf4j</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
 		<apiguardian.version>1.1.2</apiguardian.version>
 		<netty.version>4.1.73.Final</netty.version>
 		<mixpanel.version>1.4.4</mixpanel.version>
+		<org.json.version>20211205</org.json.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
@@ -70,6 +71,11 @@
 				<groupId>com.mixpanel</groupId>
 				<artifactId>mixpanel-java</artifactId>
 				<version>${mixpanel.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.json</groupId>
+				<artifactId>json</artifactId>
+				<version>${org.json.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Created mixpanel event management sending mechanism. Uses "mixpanel.log" property for each service to determine if we have to log specific mixpanel calls.

The keys involved on this first version are:

1. process.start,{{processid}}.end logs when a process is completed
2. process.var.{{varName}}.change logs when a process variable is changed
3. process.node.{{nodeName}}.trigger logs when a process task is started
4. process.node.{{nodeName}}.left logs when a process task is completed
5. rules.{{ruleName}}.fire logs when a business rule fires
