### PR TITLE
Error fix related to "NoSuchMethodError IGenericClient.registerInterceptor(IClientInterceptor)"

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -47,6 +47,7 @@
 		<logback-classic.version>1.2.10</logback-classic.version>
 		<logback-core.version>1.2.9</logback-core.version>
 		<checker-qual.version>3.8.0</checker-qual.version>		
+		<wih.version>0.0.2-SNAPSHOT</wih.version>
 	</properties>
 
 	<dependencyManagement>
@@ -220,7 +221,7 @@
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>core-wih</artifactId>
-			<version>${project.version}</version>
+			<version>${wih.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>com.thoughtworks.xstream</groupId>
@@ -269,12 +270,12 @@
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>ftl-transform-wih</artifactId>
-			<version>${project.version}</version>
+			<version>${wih.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>fhir-resource-wih</artifactId>
-			<version>${project.version}</version>
+			<version>${wih.version}</version>
 		</dependency>
 		<!-- Added for phq9-registry converters to work -->
 		<dependency>
@@ -296,7 +297,7 @@
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>cdshooks-wih</artifactId>
-			<version>${project.version}</version>
+			<version>${wih.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
@@ -895,7 +896,7 @@
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>sms-wih</artifactId>
-			<version>${project.version}</version>
+			<version>${wih.version}</version>
 		</dependency>
 	</dependencies>
 	<distributionManagement>

--- a/cdshooks-wih/pom.xml
+++ b/cdshooks-wih/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.elimu.a2d2</groupId>
   <artifactId>cdshooks-wih</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cdshooks-wih</name>

--- a/core-dependencies/fhir-parse-util/pom.xml
+++ b/core-dependencies/fhir-parse-util/pom.xml
@@ -27,6 +27,7 @@
 
 	<artifactId>fhir-parse-util</artifactId>
 	<name>FHIR Parse Utilities</name>
+	<version>0.0.2-SNAPSHOT</version>
 	<description>Implementation for FHIR Parsing utilities</description>
 
 

--- a/core-wih/pom.xml
+++ b/core-wih/pom.xml
@@ -23,6 +23,7 @@
 	<packaging>jar</packaging>
 
 	<name>core-wih</name>
+	<version>0.0.2-SNAPSHOT</version>
 	<url>http://maven.apache.org</url>
 
 	<properties>
@@ -74,6 +75,7 @@
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>generic-model</artifactId>
+			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/fhir-resource-wih/pom.xml
+++ b/fhir-resource-wih/pom.xml
@@ -23,6 +23,7 @@
 	<packaging>jar</packaging>
 
 	<name>fhir-resource-wih</name>
+	<version>0.0.2-SNAPSHOT</version>
 	<url>http://maven.apache.org</url>
 
 	<properties>
@@ -124,6 +125,7 @@
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>generic-model</artifactId>
+			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 				<groupId>org.mockito</groupId>

--- a/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/FHIRDelegateHelper.java
+++ b/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/FHIRDelegateHelper.java
@@ -61,9 +61,9 @@ public class FHIRDelegateHelper {
 				String token = authHeader.replace("Basic ", "");
 				String tokenDecrypt = new String(Base64.getDecoder().decode(token));
 				String[] parts = tokenDecrypt.split(":");
-				client.registerInterceptor(new BasicAuthInterceptor(parts[0], parts[1]));
+				client.registerInterceptor((Object) new BasicAuthInterceptor(parts[0], parts[1]));
 			} else if (authHeader.startsWith("Bearer ")) {
-				client.registerInterceptor(new BearerTokenAuthInterceptor(authHeader.replace("Bearer ", "")));
+				client.registerInterceptor((Object) new BearerTokenAuthInterceptor(authHeader.replace("Bearer ", "")));
 			}
 		}
 		}catch(Exception ex) {

--- a/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/FHIRDelegateHelper.java
+++ b/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/FHIRDelegateHelper.java
@@ -63,6 +63,7 @@ public class FHIRDelegateHelper {
 				String[] parts = tokenDecrypt.split(":");
 				client.registerInterceptor((Object) new BasicAuthInterceptor(parts[0], parts[1]));
 			} else if (authHeader.startsWith("Bearer ")) {
+				log.info("About to set BearerTokenAuthInterceptor...");
 				client.registerInterceptor((Object) new BearerTokenAuthInterceptor(authHeader.replace("Bearer ", "")));
 			}
 		}

--- a/ftl-transform-wih/pom.xml
+++ b/ftl-transform-wih/pom.xml
@@ -24,6 +24,7 @@
 		<version>0.0.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>ftl-transform-wih</artifactId>
+	<version>0.0.2-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>ftl-transform-wih</name>
@@ -93,6 +94,7 @@
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>kie-based-services</artifactId>
+			<version>${project.parent.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-codec</groupId>
@@ -110,7 +112,20 @@
 					<groupId>org.codehaus.plexus</groupId>
 					<artifactId>plexus-utils</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>io.elimu.a2d2</groupId>
+					<artifactId>service-daos</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.elimu.a2d2</groupId>
+					<artifactId>generic-model</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>io.elimu.a2d2</groupId>
+			<artifactId>service-daos</artifactId>
+			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.quartz-scheduler</groupId>
@@ -126,12 +141,18 @@
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>cds-hook-model</artifactId>
+			<version>${project.parent.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>
    			 		<artifactId>slf4j-api</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>io.elimu.a2d2</groupId>
+			<artifactId>generic-model</artifactId>
+			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -596,7 +596,7 @@
 		<dependency>
 			<groupId>org.aspectj</groupId>
     			<artifactId>aspectjweaver</artifactId>
-    			<version>1.9.6</version>
+    			<version>1.9.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jsoup</groupId>

--- a/sms-wih/pom.xml
+++ b/sms-wih/pom.xml
@@ -23,6 +23,7 @@
 	<packaging>jar</packaging>
 
 	<name>sms-wih</name>
+	<version>0.0.2-SNAPSHOT</version>
 	<url>https://www.elimu.io</url>
 
 	<properties>


### PR DESCRIPTION
We were having a problem with our services because our Jenkins server was not able to get the right version of dependencies deployed. They were instead getting old snapshots. In order to prevent this, we created a new snapshot version 0.0.2-SNAPSHOT for the affected components. 