### PR TITLE
Gt 699 hapi removal

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -149,7 +149,7 @@
 			<artifactId>encoder</artifactId>
 			<version>1.2.3</version>
 		</dependency>
-		<dependency>
+		<!--dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>task-utilities</artifactId>
 			<version>1.0.0</version>
@@ -159,7 +159,7 @@
 					<artifactId>commons-io</artifactId>
 				</exclusion>
 			</exclusions>
-		</dependency>
+		</dependency-->
 		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
@@ -277,7 +277,7 @@
 			<version>${project.version}</version>
 		</dependency>
 		<!-- Added for phq9-registry converters to work -->
-		<dependency>
+		<!--dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>org.hl7.fhir.utilities</artifactId>
 			<version>${hapi.fhir.util.version}</version>
@@ -291,7 +291,7 @@
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-hl7org-dstu2</artifactId>
 			<version>${hapi.fhir.version}</version>
-		</dependency>
+		</dependency-->
 		<!-- END added for phq9-registry converters -->
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>

--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -150,17 +150,6 @@
 			<artifactId>encoder</artifactId>
 			<version>1.2.3</version>
 		</dependency>
-		<!--dependency>
-			<groupId>io.elimu.a2d2</groupId>
-			<artifactId>task-utilities</artifactId>
-			<version>1.0.0</version>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-io</groupId>
-					<artifactId>commons-io</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency-->
 		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
@@ -277,23 +266,6 @@
 			<artifactId>fhir-resource-wih</artifactId>
 			<version>${wih.version}</version>
 		</dependency>
-		<!-- Added for phq9-registry converters to work -->
-		<!--dependency>
-			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>org.hl7.fhir.utilities</artifactId>
-			<version>${hapi.fhir.util.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>hapi-fhir-converter</artifactId>
-			<version>${hapi.fhir.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>ca.uhn.hapi.fhir</groupId>
-			<artifactId>hapi-fhir-structures-hl7org-dstu2</artifactId>
-			<version>${hapi.fhir.version}</version>
-		</dependency-->
-		<!-- END added for phq9-registry converters -->
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>cdshooks-wih</artifactId>
@@ -728,7 +700,6 @@
 			<version>2.6.0</version>
 			<scope>test</scope>
 		</dependency>
-		<!-- integration with Swagger API doc generation http://goo.gl/J5FQDM -->
 		<!-- integration with Swagger API doc generation http://goo.gl/J5FQDM -->
 		<dependency>
 			<groupId>io.springfox</groupId>

--- a/cds-hook-model/pom.xml
+++ b/cds-hook-model/pom.xml
@@ -38,7 +38,7 @@
 		</dependency>
 		<!-- Avoid more HAPI FHIR dependencies than this one. They
 		     Propagate to the workbench and cause issues on all projects -->
-		<dependency>
+		<!--dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-base</artifactId>
 			<exclusions>
@@ -59,6 +59,18 @@
 					<artifactId>jackson-annotations</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency-->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/cds-hook-model/src/main/java/io/elimu/a2d2/cdsresponse/entity/CDSHookRequest.java
+++ b/cds-hook-model/src/main/java/io/elimu/a2d2/cdsresponse/entity/CDSHookRequest.java
@@ -16,8 +16,6 @@ package io.elimu.a2d2.cdsresponse.entity;
 
 import java.util.Map;
 
-import org.hl7.fhir.instance.model.api.IBaseResource;
-
 public class CDSHookRequest {
 
 	private String hook;
@@ -27,8 +25,8 @@ public class CDSHookRequest {
 	private String user;
 	private Map<String, Object> context;
 	private Map<String, Object> prefetch;
-	private Map<String, IBaseResource> contextResources;
-	private Map<String, IBaseResource> prefetchResources;
+	private Map<String, Object> contextResources;
+	private Map<String, Object> prefetchResources;
 
 	public String getHook() {
 		return hook;
@@ -103,28 +101,28 @@ public class CDSHookRequest {
 	/**
 	 * @return the contextResources
 	 */
-	public Map<String, IBaseResource> getContextResources() {
+	public Map<String, Object> getContextResources() {
 		return contextResources;
 	}
 
 	/**
 	 * @param contextResources the contextResources to set
 	 */
-	public void setContextResources(Map<String, IBaseResource> contextResources) {
+	public void setContextResources(Map<String, Object> contextResources) {
 		this.contextResources = contextResources;
 	}
 
 	/**
 	 * @return the prefetchResources
 	 */
-	public Map<String, IBaseResource> getPrefetchResources() {
+	public Map<String, Object> getPrefetchResources() {
 		return prefetchResources;
 	}
 
 	/**
 	 * @param prefetchResources the prefetchResources to set
 	 */
-	public void setPrefetchResources(Map<String, IBaseResource> prefetchResources) {
+	public void setPrefetchResources(Map<String, Object> prefetchResources) {
 		this.prefetchResources = prefetchResources;
 	}
 

--- a/cdshooks-wih/pom.xml
+++ b/cdshooks-wih/pom.xml
@@ -61,6 +61,21 @@
     	<groupId>io.elimu.a2d2</groupId>
     	<artifactId>fhir-parse-util</artifactId>
     </dependency>
+    <dependency>
+    	<groupId>ca.uhn.hapi.fhir</groupId>
+    	<artifactId>hapi-fhir-structures-dstu2</artifactId>
+    	<scope>test</scope>
+    </dependency>
+    <dependency>
+    	<groupId>ca.uhn.hapi.fhir</groupId>
+    	<artifactId>hapi-fhir-structures-dstu3</artifactId>
+    	<scope>test</scope>
+    </dependency>
+    <dependency>
+    	<groupId>ca.uhn.hapi.fhir</groupId>
+    	<artifactId>hapi-fhir-structures-r4</artifactId>
+    	<scope>test</scope>
+    </dependency>
   </dependencies>
   <parent>
   	<groupId>io.elimu.a2d2</groupId>

--- a/cdshooks-wih/src/main/java/io/elimu/a2d2/cdshookswih/DeserializeCDSHooksRequestDelegate.java
+++ b/cdshooks-wih/src/main/java/io/elimu/a2d2/cdshookswih/DeserializeCDSHooksRequestDelegate.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 
-import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.kie.api.runtime.process.WorkItem;
@@ -113,7 +112,7 @@ public class DeserializeCDSHooksRequestDelegate implements WorkItemHandler {
 			FormatType fhirVersion, String param) {
 		for (Entry<String, Object> entry : item.entrySet()) {
 			workItemResult.put(param.concat("_").concat(entry.getKey()), entry.getValue());
-			IBaseResource resource = parseResource(entry.getValue(), fhirVersion);
+			Object resource = parseResource(entry.getValue(), fhirVersion);
 			if (resource != null) {
 				workItemResult.put(param.concat("Resource_").concat(entry.getKey()), resource);
 				log.debug("Added  the {} Resource ::{}", param, entry.getKey());
@@ -121,7 +120,7 @@ public class DeserializeCDSHooksRequestDelegate implements WorkItemHandler {
 		}
 	}
 
-	private IBaseResource parseResource(Object jsonObject, FormatType fhirVersion) {
+	private Object parseResource(Object jsonObject, FormatType fhirVersion) {
 		try {
 
 			JSONObject parsedJsonObj = null;

--- a/cdshooks-wih/src/test/java/io/elimu/a2d2/cdshooks_wih/DeserializeCDSHooksRequestDelegateTest.java
+++ b/cdshooks-wih/src/test/java/io/elimu/a2d2/cdshooks_wih/DeserializeCDSHooksRequestDelegateTest.java
@@ -15,7 +15,6 @@
 package io.elimu.a2d2.cdshooks_wih;
 
 import org.drools.core.process.instance.impl.WorkItemImpl;
-import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -25,7 +24,6 @@ import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
 import org.kie.internal.utils.KieHelper;
 
-import ca.uhn.fhir.model.api.IResource;
 import io.elimu.a2d2.cdshookswih.DeserializeCDSHooksRequestDelegate;
 import io.elimu.a2d2.exception.WorkItemHandlerException;
 
@@ -48,7 +46,7 @@ public class DeserializeCDSHooksRequestDelegateTest {
 	}
 
 	@Test
-	public void testDeserializeCDSHooksRequestDelegateForType() {
+	public void testDeserializeCDSHooksRequestDelegateForType() throws Exception {
 
 		String requestJson = "{\"hook\":\"patient-view\",\"hookInstance\":\"d1577c69-dfbe-44ad-ba6d-3e05e953b2ea\",\"fhirServer\":\""+FHIR2_SERVER_URL+"\",\"user\":\"Practitioner/COREPRACTITIONER1\",\"fhirAuthorization\":{\"accessToken\":\"cn389ncoiwuencr\",\"tokenType\":\"Bearer\",\"expiresIn\":1000,\"scope\":\"wide\",\"subject\":\"OAuth 2.0\"},\"context\":{\"patientId\":\"SMART-1288992\"},\"prefetch\":{\"patient\":{\"resourceType\":\"Patient\",\"gender\":\"male\",\"birthDate\":\"1925-12-23\",\"id\":\"SMART-1288992\",\"active\":true}}}";
 
@@ -56,13 +54,13 @@ public class DeserializeCDSHooksRequestDelegateTest {
 		execution.setParameter("requestJson", requestJson);
 		wih.executeWorkItem(execution, workItemManager);
 		Object patient=execution.getResult("prefetchResource_patient");
-		Assert.assertTrue(patient instanceof IResource);
+		Assert.assertTrue(Class.forName("ca.uhn.fhir.model.api.IResource").isAssignableFrom(patient.getClass()));
 		Assert.assertEquals(execution.getResult("prefetchResource_patient").getClass().getName(),
 				"ca.uhn.fhir.model.dstu2.resource.Patient");
 	}
 
 	@Test
-	public void testDeserializeForTypeofPatientResourceType() {
+	public void testDeserializeForTypeofPatientResourceType() throws Exception {
 
 		String requestJson = "{\"hookInstance\":\"8ce4bd47-13bc-4a0e-be15-dd3663b3c834\",\"hook\":\"patient-view\",\"fhirServer\":\""+FHIR2_SERVER_URL+"\",\"user\":\"Practitioner/COREPRACTITIONER1\",\"patient\":\"2502\",\"context\":{\"patientId\":\"2502\"},\"prefetch\":{\"patient\":{\"resourceType\":\"Patient\",\"id\":\"2502\",\"meta\":{\"versionId\":\"10\",\"lastUpdated\":\"2017-10-03T19:52:22.000+00:00\"},\"text\":{\"status\":\"generated\",\"div\":\"<div xmlns=\\\"http://www.w3.org/1999/xhtml\\\"><div class=\\\"hapiHeaderText\\\">Mr. Paul <b>WELLES </b></div><table class=\\\"hapiPropertyTable\\\"><tbody><tr><td>Identifier</td><td>98201232</td></tr><tr><td>Address</td><td><span>1 North LaSalle Street </span><br/><span>Chicago </span><span>IL </span><span>USA </span></td></tr><tr><td>Date of birth</td><td><span>02 July 1986</span></td></tr></tbody></table></div>\"},\"identifier\":[{\"use\":\"usual\",\"type\":{\"coding\":[{\"system\":\"http://hl7.org/fhir/v2/0203\",\"code\":\"MR\"}]},\"value\":\"98201232\"},{\"use\":\"usual\",\"type\":{\"coding\":[{\"system\":\"http://hl7.org/fhir/v2/0203\",\"code\":\"PLAC\"}]},\"value\":\"67890\"}],\"active\":true,\"name\":[{\"use\":\"official\",\"family\":[\"Welles\"],\"given\":[\"Paul\"],\"prefix\":[\"Mr.\"]}],\"telecom\":[{\"system\":\"phone\",\"value\":\"(312) 555-2967\",\"use\":\"mobile\"},{\"system\":\"phone\",\"use\":\"home\"}],\"gender\":\"Male\",\"birthDate\":\"1955-07-06\",\"deceasedBoolean\":false,\"address\":[{\"use\":\"home\",\"line\":[\"1 North LaSalle Street\"],\"city\":\"Chicago\",\"state\":\"IL\",\"postalCode\":\"60602\",\"country\":\"USA\"}],\"maritalStatus\":{\"coding\":[{\"system\":\"http://hl7.org/fhir/v3/MaritalStatus\",\"code\":\"M\",\"display\":\"Married\"}]},\"multipleBirthBoolean\":false,\"contact\":[{\"relationship\":[{\"coding\":[{\"system\":\"http://hl7.org/fhir/patient-contact-relationship\",\"code\":\"parent\",\"display\":\"Parent\"}]}],\"name\":{\"use\":\"usual\",\"text\":\"Mary Welles\"},\"telecom\":[{\"system\":\"phone\",\"value\":\"217-555-2016\",\"use\":\"home\"}]}],\"communication\":[{\"language\":{\"text\":\"English(US)\"}}]}}}";
 
@@ -70,11 +68,11 @@ public class DeserializeCDSHooksRequestDelegateTest {
 		execution.setParameter("requestJson", requestJson);
 		wih.executeWorkItem(execution, workItemManager);
 		Object patient=execution.getResult("prefetchResource_patient");
-		Assert.assertTrue(patient instanceof IBaseResource);
+		Assert.assertTrue(Class.forName("org.hl7.fhir.instance.model.api.IBaseResource").isAssignableFrom(patient.getClass()));
 	}
 
 	@Test
-	public void testDeserializeForTypeofQuestionnaireResponseResourceType() {
+	public void testDeserializeForTypeofQuestionnaireResponseResourceType() throws Exception {
 
 		String requestJson = "{\"hookInstance\":\"d1577c69-dfbe-44ad-ba6d-3e05e953b2ea\",\"hook\":\"questionnaire\",\"user\":\"Practitioner/123\",\"patient\":\"4591\",\"prefetch\":{\"patient\":{\"resource\":{\"resourceType\":\"Patient\",\"id\":\"4591\",\"meta\":{\"versionId\":\"3\",\"lastUpdated\":\"2017-12-04T17:30:42.000+00:00\"},\"text\":{\"status\":\"generated\",\"div\":\"<div xmlns=\\\"http://www.w3.org/1999/xhtml\\\"><div class=\\\"hapiHeaderText\\\">Mr. Al <b>GOODE </b></div><table class=\\\"hapiPropertyTable\\\"><tbody><tr><td>Identifier</td><td>9539012</td></tr><tr><td>Address</td><td></td></tr><tr><td>Date of birth</td><td><span>14 July 1965</span></td></tr></tbody></table></div>\"},\"identifier\":[{\"use\":\"usual\",\"type\":{\"coding\":[{\"system\":\"http://hl7.org/fhir/v2/0203\",\"code\":\"MR\"}]},\"system\":\"urn:oid:0.1.2.3.4.5.6.7\",\"value\":\"9539012\"}],\"active\":true,\"name\":[{\"use\":\"official\",\"family\":[\"Goode\"],\"given\":[\"Al\"],\"prefix\":[\"Mr.\"]}],\"telecom\":[{\"system\":\"phone\",\"use\":\"mobile\"},{\"system\":\"phone\",\"use\":\"home\"}],\"gender\":\"Male\",\"birthDate\":\"1965-07-14\",\"deceasedBoolean\":false,\"address\":[{\"use\":\"home\"}],\"maritalStatus\":{\"coding\":[{\"system\":\"http://hl7.org/fhir/v3/MaritalStatus\",\"code\":\"M\",\"display\":\"Married\"}]},\"multipleBirthBoolean\":false,\"contact\":[{\"relationship\":[{\"coding\":[{\"system\":\"http://hl7.org/fhir/patient-contact-relationship\",\"code\":\"partner\",\"display\":\"Partner\"}]}],\"name\":{\"use\":\"usual\",\"text\":\"Ms. Goode\"},\"telecom\":[{\"system\":\"phone\",\"use\":\"home\"}]}],\"communication\":[{\"language\":{\"text\":\"English\"}}]}}},\"context\":{\"questionnaireResponse\":{\"resourceType\":\"QuestionnaireResponse\",\"status\":\"completed\",\"authored\":\"2018-06-14T17:38:49+05:30\",\"group\":{\"linkId\":\"centor-score\",\"title\":\"centor-score\",\"question\":[{\"linkId\":\"tonsillar-exudate-boolean\",\"answer\":[{\"valueBoolean\":false}]},{\"linkId\":\"lack-of-cough-boolean\",\"answer\":[{\"valueBoolean\":false}]},{\"linkId\":\"fever-present-boolean\",\"answer\":[{\"valueBoolean\":false}]},{\"linkId\":\"swollen-nodes-boolean\",\"answer\":[{\"valueBoolean\":false}]}]}}}}";
 
@@ -82,7 +80,7 @@ public class DeserializeCDSHooksRequestDelegateTest {
 		execution.setParameter("requestJson", requestJson);
 		wih.executeWorkItem(execution, workItemManager);
 		Object patient=execution.getResult("contextResource_questionnaireResponse");
-		Assert.assertTrue(patient instanceof IBaseResource);
+		Assert.assertTrue(Class.forName("org.hl7.fhir.instance.model.api.IBaseResource").isAssignableFrom(patient.getClass()));
 	}
 
 	@Test

--- a/core-dependencies/datafetch-service/pom.xml
+++ b/core-dependencies/datafetch-service/pom.xml
@@ -57,7 +57,6 @@
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.1</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>

--- a/core-dependencies/fhir-parse-util/pom.xml
+++ b/core-dependencies/fhir-parse-util/pom.xml
@@ -43,6 +43,7 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-dstu2</artifactId>
+			<scope>test</scope>
 			<exclusions>
 				<exclusion>
 				    	<groupId>org.slf4j</groupId>
@@ -57,11 +58,11 @@
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.1</version>
 		</dependency>	
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-dstu3</artifactId>
+			<scope>test</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-codec</groupId>
@@ -72,10 +73,12 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r4</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
    			<groupId>ca.uhn.hapi.fhir</groupId>
    			<artifactId>hapi-fhir-client</artifactId>
+			<scope>test</scope>
    			<exclusions>
 				<exclusion>
 					<groupId>commons-codec</groupId>

--- a/core-dependencies/fhir-parse-util/src/main/java/io/elimu/a2d2/parsing/FhirParseUtil.java
+++ b/core-dependencies/fhir-parse-util/src/main/java/io/elimu/a2d2/parsing/FhirParseUtil.java
@@ -17,27 +17,30 @@ package io.elimu.a2d2.parsing;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import org.hl7.fhir.instance.model.api.IBaseResource;
-import ca.uhn.fhir.context.FhirContext;
 
 public class FhirParseUtil {
 
-	//TODO Change this to change amount of instances available
+	//Change this to change amount of instances available
 	private static final int AMOUNT_OF_PARSERS = Integer.parseInt(System.getProperty("fhir.parsers.count", "30"));
 
 	public static enum FormatType {
-		FHIR2(FhirContext.forDstu2()),
-		FHIR3(FhirContext.forDstu3()),
-		FHIR4(FhirContext.forR4());
+		FHIR2("forDstu2"),
+		FHIR3("forDstu3"),
+		FHIR4("forR4");
 
 
-		private final FhirContext ctx;
+		private final Object ctx;
 
-		FormatType(FhirContext ctx) {
-			this.ctx = ctx;
+		FormatType(String method) { 
+			try {
+				Class<?> ctxClass = Class.forName("ca.uhn.fhir.context.FhirContext");
+				this.ctx = ctxClass.getMethod(method).invoke(null);
+			} catch (Exception e) {
+				throw new RuntimeException("Cannot instantiate FhirContext", e);
+			}
 		}
 
-		public FhirContext getCtx() {
+		public Object getCtx() {
 			return ctx;
 		}
 	}
@@ -59,23 +62,49 @@ public class FhirParseUtil {
 	private FhirParseUtil() {
 	}
 
-	public synchronized IBaseResource parseJsonResource(FormatType type, String input) {
-		return type.getCtx().newJsonParser().parseResource(input);
+	public synchronized Object parseJsonResource(FormatType type, String input) {
+		try {
+			Object parser = type.getCtx().getClass().getMethod("newJsonParser").invoke(type.getCtx());
+			return parser.getClass().getMethod("parseResource", String.class).invoke(parser, input);
+		} catch (Exception e) {
+			throw new RuntimeException("Coudln't invoke newJsonParser.parserResource", e);
+		}
 	}
 
-	public synchronized IBaseResource parseXmlResource(FormatType type, String input) {
-		return type.getCtx().newXmlParser().parseResource(input);
+	public synchronized Object parseXmlResource(FormatType type, String input) {
+		try {
+			Object parser = type.getCtx().getClass().getMethod("newXmlParser").invoke(type.getCtx());
+			return parser.getClass().getMethod("parseResource", String.class).invoke(parser, input);
+		} catch (Exception e) {
+			throw new RuntimeException("Coudln't invoke newXmlParser.parserResource", e);
+		}
 	}
 
-	public synchronized <T extends IBaseResource> T parseResource(FormatType type, String input, Class<T> outputType) {
-		return type.getCtx().newJsonParser().parseResource(outputType, input);
+	@SuppressWarnings("unchecked")
+	public synchronized <T> T parseResource(FormatType type, String input, Class<T> outputType) {
+		try {
+			Object parser = type.getCtx().getClass().getMethod("newJsonParser").invoke(type.getCtx());
+			return (T) parser.getClass().getMethod("parseResource", Class.class, String.class).invoke(parser, outputType, input);
+		} catch (Exception e) {
+			throw new RuntimeException("Coudln't invoke newJsonParser.parserResource", e);
+		}
 	}
 
-	public synchronized String encodeJsonResource(FormatType type, IBaseResource resource) {
-		return type.getCtx().newJsonParser().encodeResourceToString(resource);
+	public synchronized String encodeJsonResource(FormatType type, Object hapiresource) {
+		try {
+			Object parser = type.getCtx().getClass().getMethod("newJsonParser").invoke(type.getCtx());
+			return (String) parser.getClass().getMethod("encodeResourceToString", Class.forName("org.hl7.fhir.instance.model.api.IBaseResource")).invoke(parser, hapiresource);
+		} catch (Exception e) {
+			throw new RuntimeException("Coudln't invoke newJsonParser.encodeResourceToString", e);
+		}
 	}
 
-	public synchronized String encodeXmlResource(FormatType type, IBaseResource resource) {
-		return type.getCtx().newXmlParser().encodeResourceToString(resource);
+	public synchronized String encodeXmlResource(FormatType type, Object hapiresource) {
+		try {
+			Object parser = type.getCtx().getClass().getMethod("newXmlParser").invoke(type.getCtx());
+			return (String) parser.getClass().getMethod("encodeResourceToString", Class.forName("org.hl7.fhir.instance.model.api.IBaseResource")).invoke(parser, hapiresource);
+		} catch (Exception e) {
+			throw new RuntimeException("Coudln't invoke newXmlParser.encodeResourceToString", e);
+		}
 	}
 }

--- a/core-dependencies/fhir-parse-util/src/main/java/io/elimu/a2d2/parsing/FhirParseUtil.java
+++ b/core-dependencies/fhir-parse-util/src/main/java/io/elimu/a2d2/parsing/FhirParseUtil.java
@@ -14,6 +14,7 @@
 
 package io.elimu.a2d2.parsing;
 
+import java.lang.reflect.Method;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -33,7 +34,8 @@ public class FhirParseUtil {
 
 		FormatType(String method) { 
 			try {
-				Class<?> ctxClass = Class.forName("ca.uhn.fhir.context.FhirContext");
+				ClassLoader cl = Thread.currentThread().getContextClassLoader();
+				Class<?> ctxClass = cl.loadClass("ca.uhn.fhir.context.FhirContext");
 				this.ctx = ctxClass.getMethod(method).invoke(null);
 			} catch (Exception e) {
 				throw new RuntimeException("Cannot instantiate FhirContext", e);
@@ -93,7 +95,9 @@ public class FhirParseUtil {
 	public synchronized String encodeJsonResource(FormatType type, Object hapiresource) {
 		try {
 			Object parser = type.getCtx().getClass().getMethod("newJsonParser").invoke(type.getCtx());
-			return (String) parser.getClass().getMethod("encodeResourceToString", Class.forName("org.hl7.fhir.instance.model.api.IBaseResource")).invoke(parser, hapiresource);
+			ClassLoader cl = Thread.currentThread().getContextClassLoader();
+			Method encodeMethod = cl.loadClass("ca.uhn.fhir.parser.JsonParser").getMethod("encodeResourceToString", cl.loadClass("org.hl7.fhir.instance.model.api.IBaseResource"));
+			return (String) encodeMethod.invoke(parser, hapiresource);
 		} catch (Exception e) {
 			throw new RuntimeException("Coudln't invoke newJsonParser.encodeResourceToString", e);
 		}
@@ -102,7 +106,9 @@ public class FhirParseUtil {
 	public synchronized String encodeXmlResource(FormatType type, Object hapiresource) {
 		try {
 			Object parser = type.getCtx().getClass().getMethod("newXmlParser").invoke(type.getCtx());
-			return (String) parser.getClass().getMethod("encodeResourceToString", Class.forName("org.hl7.fhir.instance.model.api.IBaseResource")).invoke(parser, hapiresource);
+			ClassLoader cl = Thread.currentThread().getContextClassLoader();
+			Method encodeMethod = cl.loadClass("ca.uhn.fhir.parser.XmlParser").getMethod("encodeResourceToString", cl.loadClass("org.hl7.fhir.instance.model.api.IBaseResource"));
+			return (String) encodeMethod.invoke(parser, hapiresource);
 		} catch (Exception e) {
 			throw new RuntimeException("Coudln't invoke newXmlParser.encodeResourceToString", e);
 		}

--- a/core-dependencies/fhir-parse-util/src/test/java/io/elimu/a2d2/parsing/FhirParseUtilTest.java
+++ b/core-dependencies/fhir-parse-util/src/test/java/io/elimu/a2d2/parsing/FhirParseUtilTest.java
@@ -1,0 +1,29 @@
+package io.elimu.a2d2.parsing;
+
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.elimu.a2d2.parsing.FhirParseUtil.FormatType;
+
+public class FhirParseUtilTest {
+
+	@Test
+	public void testJsonResourceParsing() {
+		Patient patient = new Patient();
+		patient.setId("1234");
+		String json = FhirParseUtil.getInstance().encodeJsonResource(FormatType.FHIR4, patient);
+		Assert.assertNotNull(json);
+		System.out.println("FhirParseUtilTest JSON = " + json);
+	}
+	
+	@Test
+	public void testXmlResourceParsing() {
+		Patient patient = new Patient();
+		patient.setId("1234");
+		String json = FhirParseUtil.getInstance().encodeXmlResource(FormatType.FHIR4, patient);
+		Assert.assertNotNull(json);
+		System.out.println("FhirParseUtilTest XML = " + json);
+	}
+	
+}

--- a/fhir-query-helper-dstu2/src/main/java/io/elimu/a2d2/cds/fhir/helper/QueryingServerHelper.java
+++ b/fhir-query-helper-dstu2/src/main/java/io/elimu/a2d2/cds/fhir/helper/QueryingServerHelper.java
@@ -74,7 +74,8 @@ public class QueryingServerHelper extends QueryingServerHelperBase<QueryingServe
 			public IBaseResource execute(FhirClientWrapper client) {
 				log.debug("Invoking url {}", resourceQuery);
 				try {
-					Class<IBaseResource> clz = (Class<IBaseResource>) Class.forName("ca.uhn.fhir.model.dstu2.resource." + resourceType);
+					ClassLoader cl = Thread.currentThread().getContextClassLoader();
+					Class<IBaseResource> clz = (Class<IBaseResource>) cl.loadClass("ca.uhn.fhir.model.dstu2.resource." + resourceType);
 					return client.fetchResourceFromUrl(clz, resourceQuery);
 				} catch (ClassNotFoundException e) {
 					log.error("ResourceType " + resourceType + " not supported for direct path reading in fhir " + client.getFhirContext().getVersion().getVersion().name());

--- a/fhir-query-helper-dstu3/src/main/java/io/elimu/a2d2/cds/fhir/helper/dstu3/QueryingServerHelper.java
+++ b/fhir-query-helper-dstu3/src/main/java/io/elimu/a2d2/cds/fhir/helper/dstu3/QueryingServerHelper.java
@@ -80,7 +80,8 @@ public class QueryingServerHelper extends QueryingServerHelperBase<QueryingServe
 			public IBaseResource execute(FhirClientWrapper client) {
 				log.debug("Invoking url {}", resourceQuery);
 				try {
-					Class<IBaseResource> clz = (Class<IBaseResource>) Class.forName("org.hl7.fhir.dstu3.model." + resourceType);
+					ClassLoader cl = Thread.currentThread().getContextClassLoader();
+					Class<IBaseResource> clz = (Class<IBaseResource>) cl.loadClass("org.hl7.fhir.dstu3.model." + resourceType);
 					return client.fetchResourceFromUrl(clz, resourceQuery);
 				} catch (ClassNotFoundException e) {
 					log.error("ResourceType " + resourceType + " not supported for direct path reading in fhir " + client.getFhirContext().getVersion().getVersion().name());

--- a/fhir-query-helper-r4/src/main/java/io/elimu/a2d2/cds/fhir/helper/r4/QueryingServerHelper.java
+++ b/fhir-query-helper-r4/src/main/java/io/elimu/a2d2/cds/fhir/helper/r4/QueryingServerHelper.java
@@ -80,7 +80,8 @@ public class QueryingServerHelper extends QueryingServerHelperBase<QueryingServe
 			public IBaseResource execute(FhirClientWrapper client) {
 				log.debug("Invoking url {}", resourceQuery);
 				try {
-					Class<IBaseResource> clz = (Class<IBaseResource>) Class.forName("org.hl7.fhir.r4.model." + resourceType);
+					ClassLoader cl = Thread.currentThread().getContextClassLoader();
+					Class<IBaseResource> clz = (Class<IBaseResource>) cl.loadClass("org.hl7.fhir.r4.model." + resourceType);
 					return client.fetchResourceFromUrl(clz, resourceQuery);
 				} catch (ClassNotFoundException e) {
 					log.error("ResourceType " + resourceType + " not supported for direct path reading in fhir " + client.getFhirContext().getVersion().getVersion().name());

--- a/fhir-resource-wih/pom.xml
+++ b/fhir-resource-wih/pom.xml
@@ -62,10 +62,12 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-dstu2</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-dstu3</artifactId>
+			<scope>test</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-codec</groupId>
@@ -76,10 +78,12 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r4</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-client</artifactId>
+			<scope>test</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-codec</groupId>
@@ -90,6 +94,7 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-base</artifactId>
+			<scope>test</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>

--- a/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/DeserializeResourceDelegate.java
+++ b/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/DeserializeResourceDelegate.java
@@ -15,7 +15,6 @@
 package io.elimu.a2d2.fhirresourcewih;
 
 import java.util.Map;
-import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
@@ -34,7 +33,7 @@ public class DeserializeResourceDelegate implements WorkItemHandler {
 		FormatType type = FHIRDelegateHelper.getFormatTypeFromVersion((String) workItem.getParameter("fhirVersion"));
 		String json = (String) workItem.getParameter("json");
 		String xml = (String) workItem.getParameter("xml");
-		IBaseResource resource = null;
+		Object resource = null;
 		if (json != null) {
 			resource = FhirParseUtil.getInstance().parseJsonResource(type, json);
 		} else if (xml != null) {

--- a/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/FHIRDelegateHelper.java
+++ b/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/FHIRDelegateHelper.java
@@ -18,12 +18,6 @@ import java.net.URL;
 import java.util.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.rest.api.EncodingEnum;
-import ca.uhn.fhir.rest.client.api.IGenericClient;
-import ca.uhn.fhir.rest.client.impl.BaseClient;
-import ca.uhn.fhir.rest.client.interceptor.BasicAuthInterceptor;
-import ca.uhn.fhir.rest.client.interceptor.BearerTokenAuthInterceptor;
 import io.elimu.a2d2.exception.FhirServerException;
 import io.elimu.a2d2.parsing.FhirParseUtil.FormatType;
 
@@ -38,20 +32,23 @@ public class FHIRDelegateHelper {
 	private static final String FHIR3 = "FHIR3";
 	private static final String FHIR2 = "FHIR2";
 
-	public IGenericClient getFhirClient(FhirContext ctx, URL fhirUrl) {
+	public Object getFhirClient(Object ctx, URL fhirUrl) {
 
-		IGenericClient client = null;
-
-		if (fhirUrl != null) {
-			client = ctx.newRestfulGenericClient(fhirUrl.toString());
-			client.setEncoding(EncodingEnum.JSON);
-			((BaseClient) client).setDontValidateConformance(true);
+		Object client = null;
+		try {
+			if (fhirUrl != null) {
+				client = ctx.getClass().getDeclaredMethod("newRestfulGenericClient", String.class).invoke(ctx, fhirUrl.toString());
+				client.getClass().getDeclaredMethod("setEncoding", Class.forName("ca.uhn.fhir.rest.api.EncodingEnum")).invoke(client, Class.forName("ca.uhn.fhir.rest.api.EncodingEnum").getDeclaredField("JSON"));
+				client.getClass().getDeclaredMethod("setDontValidateConformance", Boolean.class).invoke(client, true);
+			}
+	
+			return client;
+		} catch (Exception e) {
+			throw new RuntimeException("Couldn't invoke client", e);
 		}
-
-		return client;
 	}
 
-	public boolean authenticateFhirServer(IGenericClient client, String authHeader) {
+	public boolean authenticateFhirServer(Object client, String authHeader) {
 
 		boolean isAuthenticated = true;
 
@@ -61,9 +58,11 @@ public class FHIRDelegateHelper {
 				String token = authHeader.replace("Basic ", "");
 				String tokenDecrypt = new String(Base64.getDecoder().decode(token));
 				String[] parts = tokenDecrypt.split(":");
-				client.registerInterceptor(new BasicAuthInterceptor(parts[0], parts[1]));
+				Object interceptor = Class.forName("ca.uhn.fhir.rest.client.interceptor.BasicAuthInterceptor").getConstructor(String.class, String.class).newInstance(parts[0], parts[1]);
+				client.getClass().getDeclaredMethod("registerInterceptor", Object.class).invoke(client, interceptor);
 			} else if (authHeader.startsWith("Bearer ")) {
-				client.registerInterceptor(new BearerTokenAuthInterceptor(authHeader.replace("Bearer ", "")));
+				Object interceptor = Class.forName("ca.uhn.fhir.rest.client.interceptor.BearerTokenAuthInterceptor").getConstructor(String.class).newInstance(authHeader.replace("Bearer ", ""));
+				client.getClass().getDeclaredMethod("registerInterceptor", Object.class).invoke(client, interceptor);
 			}
 		}
 		}catch(Exception ex) {
@@ -72,24 +71,28 @@ public class FHIRDelegateHelper {
 		return isAuthenticated;
 	}
 
-	public FhirContext getFhirContext(String fhirType) {
-		FhirContext ctx = null;
-		switch (String.valueOf(fhirType)) {
-		case DSTU2:
-			ctx = FhirContext.forDstu2();
-			break;
-		case STU3:
-			ctx = FhirContext.forDstu3();
-			break;
-		case R4:
-			ctx = FhirContext.forR4();
-			break;
-		default:
-			ctx = FhirContext.forDstu2();
-			break;
+	public Object getFhirContext(String fhirType) {
+		Object ctx = null;
+		try {
+			switch (String.valueOf(fhirType)) {
+			case DSTU2:
+				ctx = Class.forName("ca.uhn.fhir.context.FhirContext").getDeclaredMethod("forDstu2").invoke(null);
+				break;
+			case STU3:
+				ctx = Class.forName("ca.uhn.fhir.context.FhirContext").getDeclaredMethod("forDstu3").invoke(null);
+				break;
+			case R4:
+				ctx = Class.forName("ca.uhn.fhir.context.FhirContext").getDeclaredMethod("forR4").invoke(null);
+				break;
+			default:
+				ctx = Class.forName("ca.uhn.fhir.context.FhirContext").getDeclaredMethod("forDstu2").invoke(null);
+				break;
+			}
+	
+			return ctx;
+		} catch (Exception e) {
+			throw new RuntimeException("Coudln't start FhirContext", e);
 		}
-
-		return ctx;
 	}
 
 	public FormatType getFormatType(String fhirType) {

--- a/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/FHIRDelegateHelper.java
+++ b/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/FHIRDelegateHelper.java
@@ -64,7 +64,6 @@ public class FHIRDelegateHelper {
 				log.info("About to set BearerTokenAuthInterceptor...");
 				Object interceptor = Class.forName("ca.uhn.fhir.rest.client.interceptor.BearerTokenAuthInterceptor").getConstructor(String.class).newInstance(authHeader.replace("Bearer ", ""));
 				client.getClass().getDeclaredMethod("registerInterceptor", Object.class).invoke(client, interceptor);
-				client.registerInterceptor((Object) new BearerTokenAuthInterceptor(authHeader.replace("Bearer ", "")));
 			}
 		}
 		}catch(Exception ex) {

--- a/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/OperationOutcomeDelegate.java
+++ b/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/OperationOutcomeDelegate.java
@@ -1,5 +1,6 @@
 package io.elimu.a2d2.fhirresourcewih;
 
+import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -8,164 +9,45 @@ import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
 
-import ca.uhn.fhir.context.FhirContext;
 import io.elimu.a2d2.exception.WorkItemHandlerException;
 import io.elimu.a2d2.genericmodel.ServiceResponse;
+import io.elimu.a2d2.parsing.FhirParseUtil;
+import io.elimu.a2d2.parsing.FhirParseUtil.FormatType;
 
 public class OperationOutcomeDelegate implements WorkItemHandler {
 
 	public static final String ISSUE_PREFIX = "issue_";
-	
+
 	@Override
 	public void executeWorkItem(WorkItem workItem, WorkItemManager manager) {
 		String version = (String) workItem.getParameter("fhirVersion");
 		Object status = workItem.getParameter("response_status");
-		Set<String> issueIds = workItem.getParameters().keySet().stream().
-				filter(e -> e.startsWith(ISSUE_PREFIX)).
-				map(s -> s.replace(ISSUE_PREFIX, "")).
-				map(s -> s.substring(0, s.indexOf("_"))).
-				distinct().
-				collect(Collectors.toSet());
 		Object outcomeObj = null;
 		String outcomeJson = null;
 		if (version == null || "FHIR4".equalsIgnoreCase(version) || "R4".equalsIgnoreCase(version)) {
-			org.hl7.fhir.r4.model.OperationOutcome outcome = new org.hl7.fhir.r4.model.OperationOutcome();
-			for (String issueId : issueIds) {
-				Map<String, Object> subset = extractIssueDetails(workItem.getParameters(), issueId);
-				org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent issue = outcome.addIssue();
-				if (subset.containsKey("code")) {
-					String code = (String) subset.get("code");
-					issue.setCode(org.hl7.fhir.r4.model.OperationOutcome.IssueType.fromCode(code));
-				}
-				if (subset.containsKey("details") || subset.containsKey("detailsCode") || subset.containsKey("detailsSystem")) {
-					String details = (String) subset.get("details");
-					String code = (String) subset.get("detailsCode");
-					String system = (String) subset.get("detailsSystem");
-					org.hl7.fhir.r4.model.CodeableConcept cc = new org.hl7.fhir.r4.model.CodeableConcept();
-					if (code != null || system != null) {
-						org.hl7.fhir.r4.model.Coding coding = cc.addCoding();
-						if (code != null) {
-							coding.setCode(code);
-						}
-						if (system != null) {
-							coding.setSystem(system);
-						}
-					}
-					if (details != null) {
-						cc.setText(details);
-					}
-					issue.setDetails(cc);
-				}
-				if (subset.containsKey("diagnostics")) {
-					issue.setDiagnostics((String) subset.get("diagnostics"));
-				}
-				if (subset.containsKey("location")) {
-					issue.addLocation((String) subset.get("location"));
-				}
-				if (subset.containsKey("location0")) {
-					for (int index = 0; subset.containsKey("location" + index); index++) {
-						issue.addLocation((String) subset.get("location" + index));
-					}
-				}
-				if (subset.containsKey("severity")) {
-					String code = (String) subset.get("severity");
-					issue.setSeverity(org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity.fromCode(code));
-				}
-			}
+			Object outcome = createOutcome(workItem, "org.hl7.fhir.r4.model.OperationOutcome", 
+					"org.hl7.fhir.r4.model.OperationOutcome$IssueType", 
+					"org.hl7.fhir.r4.model.OperationOutcome$IssueSeverity",
+					"org.hl7.fhir.r4.model.CodeableConcept",
+					"fromCode");
 			outcomeObj = outcome;
-			outcomeJson = FhirContext.forR4().newJsonParser().encodeResourceToString(outcome);
+			outcomeJson = FhirParseUtil.getInstance().encodeJsonResource(FormatType.FHIR4, outcome);
 		} else if ("FHIR3".equalsIgnoreCase(version) || "DSTU3".equalsIgnoreCase(version)) {
-			org.hl7.fhir.dstu3.model.OperationOutcome outcome = new org.hl7.fhir.dstu3.model.OperationOutcome();
-			for (String issueId : issueIds) {
-				Map<String, Object> subset = extractIssueDetails(workItem.getParameters(), issueId);
-				org.hl7.fhir.dstu3.model.OperationOutcome.OperationOutcomeIssueComponent issue = outcome.addIssue();
-				if (subset.containsKey("code")) {
-					String code = (String) subset.get("code");
-					issue.setCode(org.hl7.fhir.dstu3.model.OperationOutcome.IssueType.fromCode(code));
-				}
-				if (subset.containsKey("details") || subset.containsKey("detailsCode") || subset.containsKey("detailsSystem")) {
-					String details = (String) subset.get("details");
-					String code = (String) subset.get("detailsCode");
-					String system = (String) subset.get("detailsSystem");
-					org.hl7.fhir.dstu3.model.CodeableConcept cc = new org.hl7.fhir.dstu3.model.CodeableConcept();
-					if (code != null || system != null) {
-						org.hl7.fhir.dstu3.model.Coding coding = cc.addCoding();
-						if (code != null) {
-							coding.setCode(code);
-						}
-						if (system != null) {
-							coding.setSystem(system);
-						}
-					}
-					if (details != null) {
-						cc.setText(details);
-					}
-					issue.setDetails(cc);
-				}
-				if (subset.containsKey("diagnostics")) {
-					issue.setDiagnostics((String) subset.get("diagnostics"));
-				}
-				if (subset.containsKey("location")) {
-					issue.addLocation((String) subset.get("location"));
-				}
-				if (subset.containsKey("location0")) {
-					for (int index = 0; subset.containsKey("location" + index); index++) {
-						issue.addLocation((String) subset.get("location" + index));
-					}
-				}
-				if (subset.containsKey("severity")) {
-					String code = (String) subset.get("severity");
-					issue.setSeverity(org.hl7.fhir.dstu3.model.OperationOutcome.IssueSeverity.fromCode(code));
-				}
-			}
+			Object outcome = createOutcome(workItem, "org.hl7.fhir.dstu3.model.OperationOutcome", 
+					"org.hl7.fhir.dstu3.model.OperationOutcome$IssueType",
+					"org.hl7.fhir.dstu3.model.OperationOutcome$IssueSeverity",
+					"org.hl7.fhir.dstu3.model.CodeableConcept",
+					"fromCode");
 			outcomeObj = outcome;
-			outcomeJson = FhirContext.forDstu3().newJsonParser().encodeResourceToString(outcome);
+			outcomeJson = FhirParseUtil.getInstance().encodeJsonResource(FormatType.FHIR3, outcome);
 		} else if ("FHIR2".equalsIgnoreCase(version) || "DSTU2".equalsIgnoreCase(version)) {
-			ca.uhn.fhir.model.dstu2.resource.OperationOutcome outcome = new ca.uhn.fhir.model.dstu2.resource.OperationOutcome();
-			for (String issueId : issueIds) {
-				Map<String, Object> subset = extractIssueDetails(workItem.getParameters(), issueId);
-				ca.uhn.fhir.model.dstu2.resource.OperationOutcome.Issue issue = outcome.addIssue();
-				if (subset.containsKey("code")) {
-					String code = (String) subset.get("code");
-					issue.setCode(ca.uhn.fhir.model.dstu2.valueset.IssueTypeEnum.forCode(code));
-				}
-				if (subset.containsKey("details") || subset.containsKey("detailsCode") || subset.containsKey("detailsSystem")) {
-					String details = (String) subset.get("details");
-					String code = (String) subset.get("detailsCode");
-					String system = (String) subset.get("detailsSystem");
-					ca.uhn.fhir.model.dstu2.composite.CodeableConceptDt cc = new ca.uhn.fhir.model.dstu2.composite.CodeableConceptDt();
-					if (code != null || system != null) {
-						ca.uhn.fhir.model.dstu2.composite.CodingDt coding = cc.addCoding();
-						if (code != null) {
-							coding.setCode(code);
-						}
-						if (system != null) {
-							coding.setSystem(system);
-						}
-					}
-					if (details != null) {
-						cc.setText(details);
-					}
-					issue.setDetails(cc);
-				}
-				if (subset.containsKey("diagnostics")) {
-					issue.setDiagnostics((String) subset.get("diagnostics"));
-				}
-				if (subset.containsKey("location")) {
-					issue.addLocation((String) subset.get("location"));
-				}
-				if (subset.containsKey("location0")) {
-					for (int index = 0; subset.containsKey("location" + index); index++) {
-						issue.addLocation((String) subset.get("location" + index));
-					}
-				}
-				if (subset.containsKey("severity")) {
-					String code = (String) subset.get("severity");
-					issue.setSeverity(ca.uhn.fhir.model.dstu2.valueset.IssueSeverityEnum.forCode(code));
-				}
-			}
+			Object outcome = createOutcome(workItem, "ca.uhn.fhir.model.dstu2.resource.OperationOutcome",
+					"ca.uhn.fhir.model.dstu2.valueset.IssueTypeEnum",
+					"ca.uhn.fhir.model.dstu2.valueset.IssueSeverityEnum",
+					"ca.uhn.fhir.model.dstu2.composite.CodeableConceptDt",
+					"forCode");
 			outcomeObj = outcome;
-			outcomeJson = FhirContext.forDstu2().newJsonParser().encodeResourceToString(outcome);
+			outcomeJson = FhirParseUtil.getInstance().encodeJsonResource(FormatType.FHIR2, outcome);
 		} else {
 			throw new WorkItemHandlerException("Unrecognized fhirVersion attribute: '" + version + "'");
 		}
@@ -178,6 +60,66 @@ public class OperationOutcomeDelegate implements WorkItemHandler {
 		serviceResponse.setResponseCode(responseCode(status));
 		results.put("serviceResponse", serviceResponse);
 		manager.completeWorkItem(workItem.getId(), results);
+	}
+
+	private Object createOutcome(WorkItem workItem, String outcomeClassName, String issueTypeClassName, String issueSeverityClassName, String ccClassName, String codeMethodName) {
+		Set<String> issueIds = workItem.getParameters().keySet().stream().
+				filter(e -> e.startsWith(ISSUE_PREFIX)).
+				map(s -> s.replace(ISSUE_PREFIX, "")).
+				map(s -> s.substring(0, s.indexOf("_"))).
+				distinct().
+				collect(Collectors.toSet());
+		try {
+			Object outcome = Class.forName(outcomeClassName).getConstructor().newInstance();
+			for (String issueId : issueIds) {
+				Map<String, Object> subset = extractIssueDetails(workItem.getParameters(), issueId);
+				Method addIssueMethod = outcome.getClass().getMethod("addIssue");
+				Object issue = addIssueMethod.invoke(outcome);
+				if (subset.containsKey("code")) {
+					String code = (String) subset.get("code");
+					Object ccode = Class.forName(issueTypeClassName).getMethod(codeMethodName, String.class).invoke(null, code);
+					issue.getClass().getMethod("setCode", Class.forName(issueTypeClassName)).invoke(issue, ccode);
+				}
+				if (subset.containsKey("details") || subset.containsKey("detailsCode") || subset.containsKey("detailsSystem")) {
+					String details = (String) subset.get("details");
+					String code = (String) subset.get("detailsCode");
+					String system = (String) subset.get("detailsSystem");
+					Object cc = Class.forName(ccClassName).getConstructor().newInstance();
+					if (code != null || system != null) {
+						Object coding = cc.getClass().getMethod("addCoding").invoke(cc);
+						if (code != null) {
+							coding.getClass().getMethod("setCode", String.class).invoke(coding, code);
+						}
+						if (system != null) {
+							coding.getClass().getMethod("setSystem", String.class).invoke(coding, system);
+						}
+					}
+					if (details != null) {
+						cc.getClass().getMethod("setText", String.class).invoke(cc, details);
+					}
+					issue.getClass().getMethod("setDetails", cc.getClass()).invoke(issue, cc);
+				}
+				if (subset.containsKey("diagnostics")) {
+					issue.getClass().getMethod("setDiagnostics", String.class).invoke(issue, subset.get("diagnostics"));
+				}
+				if (subset.containsKey("location")) {
+					issue.getClass().getMethod("addLocation", String.class).invoke(issue, subset.get("location"));
+				}
+				if (subset.containsKey("location0")) {
+					for (int index = 0; subset.containsKey("location" + index); index++) {
+						issue.getClass().getMethod("addLocation", String.class).invoke(issue, subset.get("location" + index));
+					}
+				}
+				if (subset.containsKey("severity")) {
+					String code = (String) subset.get("severity");
+					Object ccode = Class.forName(issueSeverityClassName).getMethod(codeMethodName, String.class).invoke(null, code);
+					issue.getClass().getMethod("setSeverity", ccode.getClass()).invoke(issue, ccode);
+				}
+			}
+			return outcome;
+		} catch (Exception e) {
+			throw new RuntimeException("Couldn't reflect invocations to FHIR methods", e);
+		}
 	}
 
 	private Integer responseCode(Object status) {

--- a/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/OperationOutcomeDelegate.java
+++ b/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/OperationOutcomeDelegate.java
@@ -70,21 +70,22 @@ public class OperationOutcomeDelegate implements WorkItemHandler {
 				distinct().
 				collect(Collectors.toSet());
 		try {
-			Object outcome = Class.forName(outcomeClassName).getConstructor().newInstance();
+			ClassLoader cl = Thread.currentThread().getContextClassLoader();
+			Object outcome = cl.loadClass(outcomeClassName).getConstructor().newInstance();
 			for (String issueId : issueIds) {
 				Map<String, Object> subset = extractIssueDetails(workItem.getParameters(), issueId);
 				Method addIssueMethod = outcome.getClass().getMethod("addIssue");
 				Object issue = addIssueMethod.invoke(outcome);
 				if (subset.containsKey("code")) {
 					String code = (String) subset.get("code");
-					Object ccode = Class.forName(issueTypeClassName).getMethod(codeMethodName, String.class).invoke(null, code);
-					issue.getClass().getMethod("setCode", Class.forName(issueTypeClassName)).invoke(issue, ccode);
+					Object ccode = cl.loadClass(issueTypeClassName).getMethod(codeMethodName, String.class).invoke(null, code);
+					issue.getClass().getMethod("setCode", cl.loadClass(issueTypeClassName)).invoke(issue, ccode);
 				}
 				if (subset.containsKey("details") || subset.containsKey("detailsCode") || subset.containsKey("detailsSystem")) {
 					String details = (String) subset.get("details");
 					String code = (String) subset.get("detailsCode");
 					String system = (String) subset.get("detailsSystem");
-					Object cc = Class.forName(ccClassName).getConstructor().newInstance();
+					Object cc = cl.loadClass(ccClassName).getConstructor().newInstance();
 					if (code != null || system != null) {
 						Object coding = cc.getClass().getMethod("addCoding").invoke(cc);
 						if (code != null) {
@@ -112,7 +113,7 @@ public class OperationOutcomeDelegate implements WorkItemHandler {
 				}
 				if (subset.containsKey("severity")) {
 					String code = (String) subset.get("severity");
-					Object ccode = Class.forName(issueSeverityClassName).getMethod(codeMethodName, String.class).invoke(null, code);
+					Object ccode = cl.loadClass(issueSeverityClassName).getMethod(codeMethodName, String.class).invoke(null, code);
 					issue.getClass().getMethod("setSeverity", ccode.getClass()).invoke(issue, ccode);
 				}
 			}

--- a/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/SerializeResourceDelegate.java
+++ b/fhir-resource-wih/src/main/java/io/elimu/a2d2/fhirresourcewih/SerializeResourceDelegate.java
@@ -15,7 +15,6 @@
 package io.elimu.a2d2.fhirresourcewih;
 
 import java.util.Map;
-import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
@@ -42,9 +41,9 @@ public class SerializeResourceDelegate implements WorkItemHandler {
 		FormatType type = FHIRDelegateHelper.getFormatTypeFromVersion((String) workItem.getParameter("fhirVersion"));
 		String output = null;
 		if ("json".equals(outputType)) {
-			output = FhirParseUtil.getInstance().encodeJsonResource(type, (IBaseResource) payload);
+			output = FhirParseUtil.getInstance().encodeJsonResource(type, payload);
 		} else if ("xml".equals(outputType)) {
-			output = FhirParseUtil.getInstance().encodeXmlResource(type, (IBaseResource) payload);
+			output = FhirParseUtil.getInstance().encodeXmlResource(type, payload);
 		}
 		if (output == null) {
 			log.debug("Either xml or json payload was empty or invalid");

--- a/fhir-resource-wih/src/test/java/io/elimu/a2d2/fhir_resource_wih/ResourceReadDelegateTest.java
+++ b/fhir-resource-wih/src/test/java/io/elimu/a2d2/fhir_resource_wih/ResourceReadDelegateTest.java
@@ -15,6 +15,7 @@
 package io.elimu.a2d2.fhir_resource_wih;
 
 import org.drools.core.process.instance.impl.WorkItemImpl;
+import org.hl7.fhir.r4.model.codesystems.AdministrativeGender;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -25,13 +26,15 @@ import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
 import org.kie.internal.utils.KieHelper;
 import ca.uhn.fhir.model.dstu2.resource.Patient;
+import ca.uhn.fhir.model.dstu2.valueset.AdministrativeGenderEnum;
 import io.elimu.a2d2.exception.FhirServerException;
 import io.elimu.a2d2.fhirresourcewih.ResourceReadDelegate;
 
-@Ignore ("disable for now as the test is based on public testing server")
+//@Ignore ("disable for now as the test is based on public testing server")
 public class ResourceReadDelegateTest {
 
 	private static final String fhirUrl = "http://hapi.fhir.org/baseDstu2";
+	private static final String fhirUrl4 = "http://hapi.fhir.org/baseR4";
 
 	private static WorkItemManager workItemManager;
 
@@ -49,6 +52,21 @@ public class ResourceReadDelegateTest {
 	}
 
 	@Test
+	public void testFHIR4ResourceReadDelegate() {
+
+		String patientId = "2162201";
+		WorkItemImpl execution = new WorkItemImpl();
+		execution.setParameter("fhirServer", fhirUrl4);
+		execution.setParameter("resourceType", "Patient");
+		execution.setParameter("resourceId", patientId);
+		execution.setParameter("fhirVersion", "DSTU2");
+
+		wih.executeWorkItem(execution, workItemManager);
+
+		Assert.assertNotNull(execution.getResult("resource"));
+	}
+	
+	@Test
 	public void testFHIRResourceReadDelegate() {
 
 		DelegateHelperTest.setUrl(fhirUrl);
@@ -59,7 +77,7 @@ public class ResourceReadDelegateTest {
 		execution.setParameter("fhirServer", fhirUrl);
 		execution.setParameter("resourceType", patient.getResourceName());
 		execution.setParameter("resourceId", patientId);
-		execution.setParameter("fhirVersion", "DSTU2");
+		execution.setParameter("fhirVersion", "R4");
 
 		wih.executeWorkItem(execution, workItemManager);
 
@@ -68,6 +86,7 @@ public class ResourceReadDelegateTest {
 		DelegateHelperTest.deleteResourceByPatient(patientId);
 
 	}
+	
 
 	@Test(expected = FhirServerException.class)
 	public void testFHIRResourceReadDelegateResourceTypeMissing() {

--- a/fhir-resource-wih/src/test/java/io/elimu/a2d2/fhir_resource_wih/ResourceWriteDelegateTest.java
+++ b/fhir-resource-wih/src/test/java/io/elimu/a2d2/fhir_resource_wih/ResourceWriteDelegateTest.java
@@ -35,7 +35,7 @@ import io.elimu.a2d2.exception.FhirServerException;
 import io.elimu.a2d2.fhirresourcewih.FHIRDelegateHelper;
 import io.elimu.a2d2.fhirresourcewih.ResourceWriteDelegate;
 
-//@Ignore ("disable for now as the test is based on public testing server")
+@Ignore ("disable for now as the test is based on public testing server")
 public class ResourceWriteDelegateTest {
 
 	private static WorkItemManager workItemManager;

--- a/fhir-resource-wih/src/test/java/io/elimu/a2d2/fhir_resource_wih/ResourceWriteDelegateTest.java
+++ b/fhir-resource-wih/src/test/java/io/elimu/a2d2/fhir_resource_wih/ResourceWriteDelegateTest.java
@@ -14,6 +14,8 @@
 
 package io.elimu.a2d2.fhir_resource_wih;
 
+import java.net.URL;
+
 import org.drools.core.process.instance.impl.WorkItemImpl;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -24,14 +26,16 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
 import org.kie.internal.utils.KieHelper;
+
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.impl.BaseClient;
 import io.elimu.a2d2.exception.FhirServerException;
+import io.elimu.a2d2.fhirresourcewih.FHIRDelegateHelper;
 import io.elimu.a2d2.fhirresourcewih.ResourceWriteDelegate;
 
-@Ignore ("disable for now as the test is based on public testing server")
+//@Ignore ("disable for now as the test is based on public testing server")
 public class ResourceWriteDelegateTest {
 
 	private static WorkItemManager workItemManager;
@@ -64,6 +68,13 @@ public class ResourceWriteDelegateTest {
 
 		workItemManager.registerWorkItemHandler("ResourceWriteDelegate", wih);
 
+	}
+
+	@Test
+	public void testDelegatehelper() throws Exception {
+		FHIRDelegateHelper helper = new FHIRDelegateHelper();
+		Object ctx = helper.getFhirContext("R4");
+		helper.getFhirClient(ctx, new URL(FHIR2_URL));
 	}
 
 	@Test

--- a/ftl-transform-wih/pom.xml
+++ b/ftl-transform-wih/pom.xml
@@ -42,14 +42,17 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-dstu2</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-dstu3</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-client</artifactId>
+			<scope>test</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-codec</groupId>
@@ -60,6 +63,7 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-base</artifactId>
+			<scope>test</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-codec</groupId>
@@ -141,6 +145,10 @@
 		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+   	 		<artifactId>slf4j-api</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -151,6 +151,11 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>jcl-over-slf4j</artifactId>
+			<version>1.7.30</version>
+		</dependency>
+		<dependency>
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-utils</artifactId>
 			<version>3.4.1</version>
@@ -263,6 +268,10 @@
 				<exclusion>
 					<groupId>com.fasterxml.jackson.core</groupId>
 					<artifactId>jackson-databind</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+    					<artifactId>jcl-over-slf4j</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/oauth-helpers/src/main/java/io/elimu/a2d2/OAuthHelper.java
+++ b/oauth-helpers/src/main/java/io/elimu/a2d2/OAuthHelper.java
@@ -19,7 +19,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.kie.api.runtime.rule.RuleContext;
 
 import io.elimu.a2d2.cds.fhir.helper.QueryingServerHelperBase;
@@ -87,11 +86,11 @@ public class OAuthHelper {
 		return token;
 	}
 	
-	public static <T> T addOAuthToken(RuleContext context, QueryingServerHelperBase<T, IBaseResource> qsh) throws IllegalAccessException {
+	public static <T> T addOAuthToken(RuleContext context, QueryingServerHelperBase<T, ?> qsh) throws IllegalAccessException {
 		return addOAuthToken(context, qsh, "fhirScope", "fhirTokenUrl", "fhirClientId", "fhirClientSecret", "fhirPassword", "fhirUsername", "fhirGrantType");
 	}
 	
-	public static <T> T addOAuthToken(RuleContext context, QueryingServerHelperBase<T, IBaseResource> qsh,
+	public static <T> T addOAuthToken(RuleContext context, QueryingServerHelperBase<T, ?> qsh,
 			String scopeKey, String tokenUrlKey, String clientIdKey, String clientSecretKey, 
 			String passwordKey, String usernameKey, String grantTypeKey) throws IllegalAccessException {
 		List<String> params = new LinkedList<>();

--- a/task-utilities/pom.xml
+++ b/task-utilities/pom.xml
@@ -144,16 +144,19 @@
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-dstu2</artifactId>
 			<version>${hapi.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-dstu3</artifactId>
 			<version>${hapi.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r4</artifactId>
 			<version>${hapi.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -165,11 +168,13 @@
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-client</artifactId>
 			<version>${hapi.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-base</artifactId>
 			<version>${hapi.version}</version>
+			<scope>test</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>com.google.guava</groupId>

--- a/task-utilities/src/main/java/io/elimu/task/fhir/FhirTaskEventListener.java
+++ b/task-utilities/src/main/java/io/elimu/task/fhir/FhirTaskEventListener.java
@@ -235,9 +235,10 @@ public abstract class FhirTaskEventListener implements TaskLifeCycleEventListene
 			inputs = event.getTask().getTaskData().getTaskInputVariables();
 		}
 		try {
+			ClassLoader cl = Thread.currentThread().getContextClassLoader();
 			Object client = newFhirClient((String) wfInstance.getVariable(fhirServerVariableName));
 			Object execPath = client.getClass().getMethod("update").invoke(client);
-			execPath = execPath.getClass().getMethod("resource", Class.forName("org.hl7.fhir.instance.model.api.IBaseResource")).invoke(execPath, toFhirTask(event));
+			execPath = execPath.getClass().getMethod("resource", cl.loadClass("org.hl7.fhir.instance.model.api.IBaseResource")).invoke(execPath, toFhirTask(event));
 			execPath = execPath.getClass().getMethod("execute").invoke(execPath);
 			assertValidOutcome(wfInstance, execPath);
 		} catch (ReflectiveOperationException e) {
@@ -248,7 +249,8 @@ public abstract class FhirTaskEventListener implements TaskLifeCycleEventListene
 	protected Object newFhirClient(String baseUrl) throws ReflectiveOperationException {
 		Object ctx = getFhirContext();
 		Object client = ctx.getClass().getMethod("newRestfulGenericClient", String.class).invoke(ctx, baseUrl);
-		Class<?> encEnumClass = Class.forName("ca.uhn.fhir.rest.api.EncodingEnum");
+		ClassLoader cl = Thread.currentThread().getContextClassLoader();
+		Class<?> encEnumClass = cl.loadClass("ca.uhn.fhir.rest.api.EncodingEnum");
 		client.getClass().getMethod("setEncoding", encEnumClass).invoke(client, encEnumClass.getField("JSON").get(null));
 		client.getClass().getMethod("setDontValidateConformance", boolean.class).invoke(client, true);
 		return client;
@@ -277,7 +279,8 @@ public abstract class FhirTaskEventListener implements TaskLifeCycleEventListene
 			Object client = newFhirClient(url);
 			final Object fhirTask = toFhirTask(event);
 			Object execPath = client.getClass().getMethod("create").invoke(client);
-			Class<?> ibaseResClass = Class.forName("org.hl7.fhir.instance.model.api.IBaseResource");
+			ClassLoader cl = Thread.currentThread().getContextClassLoader();
+			Class<?> ibaseResClass = cl.loadClass("org.hl7.fhir.instance.model.api.IBaseResource");
 			execPath = execPath.getClass().getMethod("resource", ibaseResClass).invoke(execPath, fhirTask);
 			Object out = execPath.getClass().getMethod("execute").invoke(execPath);
 			assertValidOutcome(wfInstance, out);

--- a/task-utilities/src/main/java/io/elimu/task/fhir/r4/R4FhirTaskEventListener.java
+++ b/task-utilities/src/main/java/io/elimu/task/fhir/r4/R4FhirTaskEventListener.java
@@ -3,23 +3,14 @@ package io.elimu.task.fhir.r4;
 import java.io.File;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.net.URLEncoder;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.xml.bind.JAXBContext;
 
-import org.apache.commons.codec.digest.Md5Crypt;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.DomainResource;
-import org.hl7.fhir.r4.model.OperationOutcome;
-import org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent;
-import org.hl7.fhir.r4.model.Subscription;
-import org.hl7.fhir.r4.model.Subscription.SubscriptionChannelComponent;
-import org.hl7.fhir.r4.model.Task;
 import org.jbpm.services.task.impl.model.xml.JaxbAttachment;
 import org.jbpm.services.task.impl.model.xml.JaxbComment;
 import org.jbpm.services.task.impl.model.xml.JaxbContent;
@@ -38,10 +29,6 @@ import org.kie.api.task.TaskEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.rest.api.MethodOutcome;
-import ca.uhn.fhir.rest.client.api.IGenericClient;
-import ca.uhn.fhir.rest.gclient.StringClientParam;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateExceptionHandler;
@@ -56,7 +43,7 @@ public class R4FhirTaskEventListener extends io.elimu.task.fhir.FhirTaskEventLis
 	}
 
 	@Override
-	protected IBaseResource toFhirTask(TaskEvent event) {
+	protected Object toFhirTask(TaskEvent event) {
 		try {
 			String fileContent = IOUtils.toString(getClass().getResourceAsStream("/taskTemplate.ftl"), "UTF-8");
 			File file = File.createTempFile("taskTemplate.ftl", ".ftl");
@@ -76,7 +63,9 @@ public class R4FhirTaskEventListener extends io.elimu.task.fhir.FhirTaskEventLis
 	        templateData.put("event", event);
 	        template.process(templateData, processedOutput);
 	        String json = processedOutput.getBuffer().toString();
-	        return getFhirContext().newJsonParser().parseResource(json);
+	        Object ctx = getFhirContext();
+	        Object parser = ctx.getClass().getMethod("newJsonParser").invoke(ctx);
+	        return parser.getClass().getMethod("parseResource", String.class).invoke(parser, json);
 		} catch (Exception e) {
 			LOG.error("Couldn't transform jBPM task to FHIR task", e);
 			throw new RuntimeException("Error", e);
@@ -84,27 +73,43 @@ public class R4FhirTaskEventListener extends io.elimu.task.fhir.FhirTaskEventLis
 	}
 
 	@Override
-	protected void setId(IBaseResource resource, String id) {
-		((DomainResource) resource).setId(id);
+	protected void setId(Object resource, String id) throws ReflectiveOperationException {
+		resource.getClass().getMethod("setId", String.class).invoke(resource, id);
 	}
 
 	@Override
-	protected FhirContext getFhirContext() {
-		return FhirContext.forR4();
+	protected Object getFhirContext() throws ReflectiveOperationException {
+		return Class.forName("ca.uhn.fhir.context.FhirContext").getMethod("forR4").invoke(null);
 	}
 
 	@Override
-	protected String getFhirSubscriptionId(IGenericClient client, TaskEvent event) {
+	protected String getFhirSubscriptionId(Object client, TaskEvent event) throws ReflectiveOperationException {
 		WorkflowProcessInstance wfInstance = super.getProcessVariables(event);
 		String url = getSubscriptionUrl(wfInstance);
-		Bundle bundle = (Bundle) client.search().forResource(Subscription.class)
-			.where(new StringClientParam("criteria").matchesExactly().value("Task?"))
-			.execute();
-		if (bundle.hasEntry()) {
-			for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
-				Subscription sub = (Subscription) entry.getResource();
-				if (sub != null && sub.getChannel() != null && url.equals(sub.getChannel().getEndpoint())) {
-					return sub.getId();
+		Object searchPath = client.getClass().getMethod("search").invoke(client);
+		searchPath = searchPath.getClass().getMethod("forResource", Class.class).invoke(searchPath, Class.forName("org.hl7.fhir.r4.model.Subscription"));
+		Class<?> strClientParamClass = Class.forName("ca.uhn.fhir.rest.gclient.StringClientParam");
+		Object strClientParam = strClientParamClass.getConstructor(String.class).newInstance("criteria");
+		strClientParam = strClientParam.getClass().getMethod("matchesExactly").invoke(strClientParam);
+		strClientParam = strClientParam.getClass().getMethod("value", String.class).invoke(strClientParam, "Task?");
+		searchPath = searchPath.getClass().getMethod("where", strClientParamClass).invoke(searchPath, strClientParam);
+		Object bundle = searchPath.getClass().getMethod("execute").invoke(searchPath);
+		boolean hasEntry = (boolean) bundle.getClass().getMethod("hasEntry").invoke(bundle);
+		if (hasEntry) {
+			List<?> entries = (List<?>) bundle.getClass().getMethod("getEntry").invoke(bundle);
+			for (Object entry : entries) {
+				Object sub = entry.getClass().getMethod("getResource").invoke(entry);
+				if (sub != null) {
+					Object channel = sub.getClass().getMethod("getChannel").invoke(sub);
+					if (channel != null) {
+						Object endpoint = channel.getClass().getMethod("getEndpoint").invoke(channel);
+						if (url.equals(endpoint)) {
+							Object id = sub.getClass().getMethod("getId").invoke(sub);
+							if (id != null) {
+								return id.toString();
+							}
+						}
+					}
 				}
 			}
 		}
@@ -120,22 +125,24 @@ public class R4FhirTaskEventListener extends io.elimu.task.fhir.FhirTaskEventLis
 	}
 
 	@Override
-	protected IBaseResource toFhirSubscription(TaskEvent event) {
+	protected Object toFhirSubscription(TaskEvent event) throws ReflectiveOperationException {
 		try {
-			Subscription sub = new Subscription();
-			SubscriptionChannelComponent channel = new SubscriptionChannelComponent();
+			Object sub = Class.forName("org.hl7.fhir.r4.model.Subscription").getConstructor().newInstance();
+			Object channel = Class.forName("org.hl7.fhir.r4.model.Subscription$SubscriptionChannelComponent").getConstructor().newInstance();
 			WorkflowProcessInstance wfInstance = super.getProcessVariables(event);
 			getSubscriptionUrl(wfInstance);
 			String microserviceAuth = (String) wfInstance.getVariable(microserviceAuthVariableName);
-			channel.setEndpoint(getSubscriptionUrl(wfInstance));
-			channel.setType(Subscription.SubscriptionChannelType.RESTHOOK);
-			channel.setPayload("application/fhir+json");
+			channel.getClass().getMethod("setEndpoint", String.class).invoke(channel, getSubscriptionUrl(wfInstance));
+			Class<?> subChannelTypeClass = Class.forName("org.hl7.fhir.r4.model.Subscription$SubscriptionChannelType");
+			channel.getClass().getMethod("setType", subChannelTypeClass).invoke(channel, subChannelTypeClass.getField("RESTHOOK").get(null));
+			channel.getClass().getMethod("setPayload", String.class).invoke(channel, "application/fhir+json");
 			if (microserviceAuth != null) {
-				channel.addHeader("Authorization: Basic " + microserviceAuth);
+				channel.getClass().getMethod("addHeader", String.class).invoke(channel, "Authorization: Basic " + microserviceAuth);
 			}
-			sub.setChannel(channel);
-			sub.setStatus(Subscription.SubscriptionStatus.REQUESTED);
-			sub.setCriteria("Task?");
+			sub.getClass().getMethod("setChannel", channel.getClass()).invoke(sub, channel);
+			Class<?> subStatusClass = Class.forName("org.hl7.fhir.r4.model.Subscription$SubscriptionStatus");
+			sub.getClass().getMethod("setStatus", subStatusClass).invoke(sub, subStatusClass.getField("REQUESTED").get(null));
+			sub.getClass().getMethod("setCriteria", String.class).invoke(sub, "Task?");
 			return sub;
 		} catch (Exception e) {
 			LOG.error("Couldn't create FHIR subscription", e);
@@ -143,7 +150,7 @@ public class R4FhirTaskEventListener extends io.elimu.task.fhir.FhirTaskEventLis
 		}
 	}
 	
-	public org.kie.api.task.model.Task toJbpmTask(Task r4task, org.kie.api.task.model.Task originalTask) {
+	public org.kie.api.task.model.Task toJbpmTask(Object r4task, org.kie.api.task.model.Task originalTask) {
 		try {
 			String fileContent = IOUtils.toString(getClass().getResourceAsStream("/jbpmTemplate.ftl"), "UTF-8");
 			File file = File.createTempFile("jbpmTemplate.ftl", ".ftl");
@@ -174,19 +181,32 @@ public class R4FhirTaskEventListener extends io.elimu.task.fhir.FhirTaskEventLis
 	}
 
 	@Override
-	protected void assertValidOutcome(WorkflowProcessInstance pInstance, MethodOutcome out) throws WorkflowRuntimeException {
-		OperationOutcome opOut = (OperationOutcome) out.getOperationOutcome();
-		if (opOut != null && opOut.getIssue() != null && !opOut.getIssue().isEmpty()) {
-			StringBuilder sb = new StringBuilder();
-			for (OperationOutcomeIssueComponent issue : opOut.getIssue()) {
-				sb.append(issue.getSeverity().name()).
-						append(" - ").append(issue.getCode().name()).
-						append(": ").append(issue.getDetails().getText()).
-						append(" (").append(issue.getDiagnostics()).append(" at location ").
-						append(issue.getLocation().toString()).append(", expression ").
-						append(issue.getExpression()).append(")\n");
+	protected void assertValidOutcome(WorkflowProcessInstance pInstance, Object out) throws WorkflowRuntimeException {
+		try {
+			Object opOut = out.getClass().getMethod("getOperationOutcome").invoke(out);
+			if (opOut != null) {
+				List<?> opOutIssue = (List<?>) opOut.getClass().getMethod("getIssue").invoke(opOut);
+				if (opOutIssue != null && !opOutIssue.isEmpty()) {
+					StringBuilder sb = new StringBuilder();
+					for (Object issue : opOutIssue) {
+						Object severity = issue.getClass().getMethod("getSeverity").invoke(issue);
+						severity = severity.getClass().getMethod("name").invoke(severity);
+						Object code = issue.getClass().getMethod("getCode").invoke(issue);
+						code = code.getClass().getMethod("name").invoke(code);
+						Object details = issue.getClass().getMethod("getDetails").invoke(issue);
+						details = details.getClass().getMethod("getText").invoke(details);
+						Object diagnostics = issue.getClass().getMethod("getDiagnostics").invoke(issue);
+						Object location = issue.getClass().getMethod("getLocation").invoke(issue);
+						Object expression = issue.getClass().getMethod("getExpression").invoke(issue);
+						sb.append(severity).append(" - ").append(code).append(": ").append(details).
+								append(" (").append(diagnostics).append(" at location ").
+								append(location).append(", expression ").append(expression).append(")\n");
+					}
+					throw new WorkflowRuntimeException(null, pInstance, new IllegalArgumentException(sb.toString()));
+				}
 			}
-			throw new WorkflowRuntimeException(null, pInstance, new IllegalArgumentException(sb.toString()));
+		} catch (ReflectiveOperationException e) {
+			throw new WorkflowRuntimeException(null, pInstance, new IllegalArgumentException("Couldn't reflect FHIR4 components", e));
 		}
 	}
 }


### PR DESCRIPTION
Removes the need for HAPI fhir to be part of the webapp classloader, allowing different services to use different versions of FHIR