### PR TITLE
mitigate tomcat embed websocket vulnerability

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -40,7 +40,7 @@
 		<jasypt.version>3.0.3</jasypt.version>
 		<commons-io.version>2.11.0</commons-io.version>
 		<maven.version>3.8.4</maven.version>
-		<tomcat-embed-websocket.version>9.0.55</tomcat-embed-websocket.version>
+		<tomcat-embed-websocket.version>9.0.62</tomcat-embed-websocket.version>
 		<spring.version>5.3.15</spring.version>
 		<resteasy-client.version>4.7.2.Final</resteasy-client.version>
 		<tomcat-embed-core.version>9.0.54</tomcat-embed-core.version>


### PR DESCRIPTION
Done with mitigate tomcat embed core, update version 9.0.56 to 9.0.62
Done with build and install and ran all integration test case



![image](https://user-images.githubusercontent.com/94971091/161551296-e429ffd6-17df-41f1-a069-32b074f9fa70.png)
