### PR TITLE
Mitigated protobuf-java vulnerability by updating version

### DIFF
--- a/cds-hook-services/pom.xml
+++ b/cds-hook-services/pom.xml
@@ -243,7 +243,16 @@
 					<groupId>org.codehaus.jackson</groupId>
 					<artifactId>jackson-mapper-asl</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-java</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>com.google.protobuf</groupId>
+			<artifactId>protobuf-java</artifactId>
+		    <version>${protobuf-java.version}</version>
 		</dependency>
 		<dependency>
 		    <groupId>com.fasterxml.jackson.core</groupId>
@@ -382,6 +391,10 @@
 				<exclusion>
 					<groupId>com.fasterxml.jackson.core</groupId>
 					<artifactId>jackson-databind</artifactId> 
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-java</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 		<spring.boot.starter.version>2.6.6</spring.boot.starter.version>
 		<spring.version>5.3.18</spring.version>
 		<jackson.version>2.12.3</jackson.version>
+		<protobuf-java.version>3.19.4</protobuf-java.version>		
 		<mockito.version>2.23.0</mockito.version>
 		<jedis.version>4.0.1</jedis.version>
 		<cds.helper.version>0.0.9</cds.helper.version>


### PR DESCRIPTION
Done with mitigate the vulnerability by updating protobuf java version from 3.6.1 to 3.19.4
Done with build ran and successfully test it on local.
![image](https://user-images.githubusercontent.com/94971091/163800983-d2b24f19-5735-4785-8928-c6987da1fd5c.png)
