### PR TITLE
Mitigated spring core vulnerability by updating version

### DIFF
--- a/core-wih/pom.xml
+++ b/core-wih/pom.xml
@@ -33,6 +33,7 @@
 	<properties>
 		<mixpanel.version>1.4.4</mixpanel.version>
 		<org.json.version>20211205</org.json.version>
+		<sping-web.version>5.3.18</sping-web.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
@@ -102,7 +103,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>5.3.8</version>
+			<version>${sping-web.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Done with mitigate spring core vulnerability in core with by updating version from 5.3.8 to 5.3.18
Done with build ran and test on the local
![image](https://user-images.githubusercontent.com/94971091/164434455-60cb8ac8-6aa9-4aa5-aa39-ef4dc442b591.png)
![image](https://user-images.githubusercontent.com/94971091/164434475-8adf4bcb-eb98-462c-9f8b-89f10d51fe79.png)
![image](https://user-images.githubusercontent.com/94971091/164434575-6ed55588-e1da-47f9-a86f-e3f8ea5a98a0.png)
