### PR TITLE
Mitigated protobuf vulernability from parent

### DIFF
--- a/core-wih/pom.xml
+++ b/core-wih/pom.xml
@@ -94,6 +94,17 @@
 			<artifactId>drools-persistence-jpa</artifactId>
 			<version>${kie.version}</version>
 			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-java</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>com.google.protobuf</groupId>
+		    <artifactId>protobuf-java</artifactId>
+		    <version>${protobuf-java.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>

--- a/generic-helpers/pom.xml
+++ b/generic-helpers/pom.xml
@@ -53,6 +53,17 @@
 			<groupId>org.drools</groupId>
 			<artifactId>drools-persistence-jpa</artifactId>
 			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-java</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>com.google.protobuf</groupId>
+		    <artifactId>protobuf-java</artifactId>
+		    <version>${protobuf-java.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -144,7 +144,16 @@
 					<groupId>org.eclipse.aether</groupId>
 					<artifactId>aether-impl</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-java</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>com.google.protobuf</groupId>
+		    <artifactId>protobuf-java</artifactId>
+		    <version>${protobuf-java.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<spring.boot.starter.version>2.6.6</spring.boot.starter.version>
 		<spring.version>5.3.18</spring.version>
 		<jackson.version>2.12.3</jackson.version>
-		<protobuf-java.version>3.19.4</protobuf-java.version>		
+		<protobuf-java.version>3.19.4</protobuf-java.version>
 		<mockito.version>2.23.0</mockito.version>
 		<jedis.version>4.0.1</jedis.version>
 		<cds.helper.version>0.0.9</cds.helper.version>

--- a/task-utilities/pom.xml
+++ b/task-utilities/pom.xml
@@ -16,6 +16,7 @@
 		<freemarker.version>2.3.30</freemarker.version>
 		<maven.version>3.8.4</maven.version>
 		<jsoup.version>1.14.2</jsoup.version>
+		<protobuf-java.version>3.19.4</protobuf-java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
@@ -85,6 +86,17 @@
 			<artifactId>jbpm-human-task-core</artifactId>
 			<version>${kie.version}</version>
 			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-java</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>com.google.protobuf</groupId>
+		    <artifactId>protobuf-java</artifactId>
+		    <version>${protobuf-java.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jbpm</groupId>
@@ -127,6 +139,10 @@
 				<exclusion>
 					<groupId>org.jsoup</groupId>
 					<artifactId>jsoup</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-java</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>


### PR DESCRIPTION
Done with mitigate protobuf-java vulnerability by updating version from 3.6.1 to 3.19.4
![image](https://user-images.githubusercontent.com/94971091/164729204-5e7dc497-ad96-4b8a-8474-b95ed84f4c82.png)
![image](https://user-images.githubusercontent.com/94971091/164729245-87ca740d-9585-4462-96a0-d417c51b1baf.png)
![image](https://user-images.githubusercontent.com/94971091/164729266-84eeb7f4-cac8-4e4f-b234-c614ba1c810b.png)
