### PR TITLE
Updating spring version to mitigate spring vulnerability

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -27,7 +27,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.6</version>
+		<version>2.6.7</version>
 		<relativePath />
 	</parent>
 

--- a/cds-hook-services/pom.xml
+++ b/cds-hook-services/pom.xml
@@ -34,7 +34,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-parent</artifactId>
-				<version>2.6.6</version>
+				<version>2.6.7</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<json-simple.version>1.1.1</json-simple.version>
 		<h2.version>2.1.210</h2.version>
 		<hibernate.version>5.4.24.Final</hibernate.version>
-		<spring.boot.starter.version>2.6.6</spring.boot.starter.version>
+		<spring.boot.starter.version>2.6.7</spring.boot.starter.version>
 		<spring.version>5.3.19</spring.version>
 		<jackson.version>2.12.3</jackson.version>
 		<protobuf-java.version>3.19.4</protobuf-java.version>

--- a/service-daos/pom.xml
+++ b/service-daos/pom.xml
@@ -30,7 +30,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-parent</artifactId>
-				<version>2.6.6</version>
+				<version>2.6.7</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
When I generate a report from master, still we are getting spring core and spring tx vulnerability with `5.3.18` , So, I also update the spring boot version from 2.6.6 to 2.6.7, Done with mitigate vulnerability, Done with build, ran and test on local
![image](https://user-images.githubusercontent.com/94971091/165264889-26c284db-ca98-428b-bcc3-e75452e07983.png)
![image](https://user-images.githubusercontent.com/94971091/165264971-9a1bd3e2-c64d-4845-9e2e-47914cf9f864.png)
![image](https://user-images.githubusercontent.com/94971091/165264997-2cb4b4fb-0d80-421e-b44e-bf901f046691.png)
![image](https://user-images.githubusercontent.com/94971091/165265066-a0f1e6ae-1334-440a-b858-f51afe205490.png)
