### PR TITLE
Fixes for QSH in memory cache, and updates to jedis cache implementation

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -304,7 +304,7 @@
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>generic-helpers</artifactId>
-			<version>0.0.11</version>
+			<version>0.0.12</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- web development, including Tomcat and spring-webmvc -->

--- a/fhir-helpers/pom.xml
+++ b/fhir-helpers/pom.xml
@@ -20,7 +20,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.elimu.a2d2</groupId>
 	<artifactId>fhir-helpers</artifactId>
-	<version>0.0.11</version>
+	<version>0.0.12</version>
 	<packaging>jar</packaging>
 	<name>fhir-helpers</name>
 	<url>http://maven.apache.org</url>

--- a/fhir-query-helper-base/pom.xml
+++ b/fhir-query-helper-base/pom.xml
@@ -27,7 +27,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-base</artifactId>
-	<version>0.0.11</version>
+	<version>0.0.12</version>
 	<description>CDS Helper base</description>
 
 	<properties>

--- a/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/cache/CacheCleaner.java
+++ b/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/cache/CacheCleaner.java
@@ -1,0 +1,83 @@
+package io.elimu.a2d2.cds.fhir.cache;
+
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.concurrent.Executors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CacheCleaner implements Runnable {
+
+	private static final Logger LOG = LoggerFactory.getLogger(CacheCleaner.class);
+	private static final CacheCleaner INSTANCE = new CacheCleaner();
+	private Thread main;
+	
+	private CacheCleaner() {
+		this.main = Executors.defaultThreadFactory().newThread(this);
+		this.main.setName("FhirQueryHelperCacheCleaner-" + this.main.getId()); 
+		this.main.start();
+	}
+	
+	public static CacheCleaner getInstance() {
+		return INSTANCE;
+	}
+	
+	@Override
+	protected void finalize() throws Throwable {
+		this.main.interrupt();
+	}
+
+	public static class CacheReference {
+		private final String key;
+		private final CacheService<?> service;
+		private final long timestamp;
+		
+		public CacheReference(String key, CacheService<?> service, long timestamp) {
+			this.key = key;
+			this.service = service;
+			this.timestamp = timestamp;
+		}
+		
+		public String getKey() {
+			return key;
+		}
+		
+		public CacheService<?> getService() {
+			return service;
+		}
+		
+		public long getTimestamp() {
+			return timestamp;
+		}
+	}
+	
+	PriorityQueue<CacheReference> queue = new PriorityQueue<>(Comparator.comparingLong(CacheReference::getTimestamp));
+	
+	@Override
+	public void run() {
+		try {
+			while(true) {
+				if (queue.isEmpty()) {
+					Thread.sleep(100);
+					continue;
+				}
+				CacheReference ref = queue.remove();
+				int cleanupsDone = 0;
+				if (System.currentTimeMillis() > ref.getTimestamp()) {
+					ref.getService().delete(ref.getKey());
+					cleanupsDone++;
+				} else {
+					queue.add(ref);
+				}
+				if (cleanupsDone > 0) {
+					LOG.debug("Cache cleaned up " + cleanupsDone + " old entries.");
+				}
+			}
+		} catch (Exception e) { }
+	}
+
+	public void register(String key, long timeout, CacheService<?> service) {
+		queue.add(new CacheReference(key, service, timeout));
+	}
+}

--- a/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/cache/CacheUtil.java
+++ b/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/cache/CacheUtil.java
@@ -39,7 +39,7 @@ public class CacheUtil {
 	public static final String CACHE_TYPE_PROPERTY = System.getProperty("cache.type.impl", "NO_CACHE");
 	public static final String PREFIX_KEY = System.getProperty("cache.prefix", "a2d2");
 	public static final String BASIC = "Basic";
-
+	
 	private static final List<Integer> VALID_STATES = Arrays.asList(200);
 
 	private CacheUtil() {

--- a/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/cache/InMemoryCache.java
+++ b/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/cache/InMemoryCache.java
@@ -45,7 +45,7 @@ public class InMemoryCache implements CacheService<ResponseEvent<FhirResponse<?>
 	@Override
 	public void put(String key, ResponseEvent<FhirResponse<?>> value) {
 		responsesCache.put(key, value);
-
+		CacheCleaner.getInstance().register(key, value.getTimeout(), this);
 	}
 
 	@Override

--- a/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/cache/JedisCache.java
+++ b/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/cache/JedisCache.java
@@ -16,19 +16,23 @@ package io.elimu.a2d2.cds.fhir.cache;
 
 import java.time.Duration;
 import java.util.Set;
+
 import io.elimu.a2d2.cds.fhir.cache.CacheUtil.CACHE_TYPE;
 import io.elimu.a2d2.cds.fhir.helper.FhirResponse;
 import io.elimu.a2d2.cds.fhir.helper.ResponseEvent;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.Protocol;
 
 public class JedisCache implements CacheService<ResponseEvent<FhirResponse<?>>> {
 
 	private CACHE_TYPE cacheType = null;
 
 	private static final int JEDIS_PORT = Integer.parseInt(System.getProperty("cache.jedis.port", "6379"));
+	private static final String JEDIS_PWD = System.getProperty("cache.jedis.password");
 	private static final String JEDIS_HOST = System.getProperty("cache.jedis.host", "localhost");
+	private static final Boolean JEDIS_SSL = Boolean.valueOf(System.getProperty("cache.jedis.use_ssl", "false"));
 	private static final int JEDIS_TIMEOUT_CONNECTION = Integer.parseInt(System.getProperty("cache.jedis.connection.timeout", "10000")); //milliseconds (default timeout 2000)
 	private static final int JEDIS_TIMEOUT_KEY_SECONDS = Integer.parseInt(System.getProperty("cache.jedis.key.timeout", "1800")); //1800 = 30 minutes
 
@@ -46,7 +50,7 @@ public class JedisCache implements CacheService<ResponseEvent<FhirResponse<?>>> 
 	@Override
 	public void connect() {
 		if(jedisPool == null) {
-			jedisPool = new JedisPool(buildPoolConfig(), JEDIS_HOST, JEDIS_PORT, JEDIS_TIMEOUT_CONNECTION);
+			jedisPool = new JedisPool(buildPoolConfig(), JEDIS_HOST, JEDIS_PORT, JEDIS_TIMEOUT_CONNECTION, JEDIS_PWD, Protocol.DEFAULT_DATABASE, JEDIS_SSL);
 			jedis = jedisPool.getResource();
 		}
 	}

--- a/fhir-query-helper-dstu2/pom.xml
+++ b/fhir-query-helper-dstu2/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-dstu2</artifactId>
-	<version>0.0.11</version>
+	<version>0.0.12</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper</description>
 

--- a/fhir-query-helper-dstu3/pom.xml
+++ b/fhir-query-helper-dstu3/pom.xml
@@ -26,7 +26,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-dstu3</artifactId>
-	<version>0.0.11</version>
+	<version>0.0.12</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper DSTU3</description>
 

--- a/fhir-query-helper-r4/pom.xml
+++ b/fhir-query-helper-r4/pom.xml
@@ -26,7 +26,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-r4</artifactId>
-	<version>0.0.11</version>
+	<version>0.0.12</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper R4</description>
 

--- a/generic-helpers/pom.xml
+++ b/generic-helpers/pom.xml
@@ -23,7 +23,7 @@
 		<version>0.0.9-SNAPSHOT</version>
 	</parent>
 	<artifactId>generic-helpers</artifactId>
-	<version>0.0.11</version>
+	<version>0.0.12</version>
 	<name>Base helpers for the Generic services</name>
 	<description>Contains WIHInvoker</description>
 

--- a/oauth-helpers/pom.xml
+++ b/oauth-helpers/pom.xml
@@ -27,7 +27,7 @@
 	</parent>
 
 	<artifactId>oauth-helpers</artifactId>
-	<version>0.0.11</version>
+	<version>0.0.12</version>
 	<description>OAuth Helper</description>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<protobuf-java.version>3.19.4</protobuf-java.version>
 		<mockito.version>2.23.0</mockito.version>
 		<jedis.version>4.0.1</jedis.version>
-		<cds.helper.version>0.0.11</cds.helper.version>
+		<cds.helper.version>0.0.12</cds.helper.version>
 		<freemarker.version>2.3.30</freemarker.version>
 		<jacoco.version>0.8.7</jacoco.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>


### PR DESCRIPTION
The in-memory cache was failing to cleanup after the allotted amount of time. Also, the jedis implementation needed to account for SSL and a password as an option for the connection