### PR TITLE
Mitigate Spring related dependency

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -27,7 +27,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.1</version>
+		<version>2.7.4</version>
 		<relativePath />
 	</parent>
 
@@ -40,7 +40,7 @@
 		<commons-io.version>2.11.0</commons-io.version>
 		<maven.version>3.8.4</maven.version>
 		<tomcat-embed-websocket.version>9.0.62</tomcat-embed-websocket.version>
-		<spring.version>5.3.21</spring.version>
+		<spring.version>5.3.23</spring.version>
 		<resteasy-client.version>4.7.2.Final</resteasy-client.version>
 		<tomcat-embed-core.version>9.0.62</tomcat-embed-core.version>
 		<log4j.version>2.17.1</log4j.version>

--- a/cds-hook-services/pom.xml
+++ b/cds-hook-services/pom.xml
@@ -34,7 +34,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-parent</artifactId>
-				<version>2.7.1</version>
+				<version>2.7.4</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/core-wih/pom.xml
+++ b/core-wih/pom.xml
@@ -33,7 +33,7 @@
 	<properties>
 		<mixpanel.version>1.4.4</mixpanel.version>
 		<org.json.version>20211205</org.json.version>
-		<sping-web.version>5.3.21</sping-web.version>
+		<sping-web.version>5.3.23</sping-web.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
 		<json-simple.version>1.1.1</json-simple.version>
 		<h2.version>2.1.210</h2.version>
 		<hibernate.version>5.4.24.Final</hibernate.version>
-		<spring.boot.starter.version>2.7.1</spring.boot.starter.version>
-		<spring.version>5.3.21</spring.version>
+		<spring.boot.starter.version>2.7.4</spring.boot.starter.version>
+		<spring.version>5.3.23</spring.version>
 		<jackson.version.databind>2.12.6.1</jackson.version.databind>
 		<jackson.version>2.12.6</jackson.version>
 		<protobuf-java.version>3.19.4</protobuf-java.version>

--- a/service-daos/pom.xml
+++ b/service-daos/pom.xml
@@ -30,7 +30,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-parent</artifactId>
-				<version>2.7.1</version>
+				<version>2.7.4</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
Mitigate spring boot by updating its version from 2.7.1 to 2.7.4
Mitigate Spring core by updating its version from 5.3.21 to 5.3.23
Done with build, run and  test it on local by running unit test cases and integration test cases of omnibus on local,
Also update same version in omnibus, Creating PR for same.
![image](https://user-images.githubusercontent.com/94971091/192514638-f19abd3d-d5e1-42c1-9691-b96ebfa56e10.png)
![image](https://user-images.githubusercontent.com/94971091/192514712-1708b9a9-f6b0-4360-82d6-153f352178fe.png)
