### PR TITLE
Mitigate tomcat from 9.0.62 to 9.0.65

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -39,10 +39,10 @@
 		<jasypt.version>3.0.3</jasypt.version>
 		<commons-io.version>2.11.0</commons-io.version>
 		<maven.version>3.8.4</maven.version>
-		<tomcat-embed-websocket.version>9.0.62</tomcat-embed-websocket.version>
+		<tomcat-embed-websocket.version>9.0.65</tomcat-embed-websocket.version>
 		<spring.version>5.3.23</spring.version>
 		<resteasy-client.version>4.7.2.Final</resteasy-client.version>
-		<tomcat-embed-core.version>9.0.62</tomcat-embed-core.version>
+		<tomcat-embed-core.version>9.0.65</tomcat-embed-core.version>
 		<log4j.version>2.17.1</log4j.version>
 		<logback-classic.version>1.2.10</logback-classic.version>
 		<logback-core.version>1.2.9</logback-core.version>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -10,13 +10,6 @@
    </suppress>
    <suppress>
       <notes><![CDATA[
-      file name: spring-web-5.3.23.jar
-      ]]></notes>
-      <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
-      <cve>CVE-2016-1000027</cve>
-   </suppress>
-   <suppress>
-      <notes><![CDATA[
       file name: snakeyaml-1.30.jar
       ]]></notes>
       <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>


### PR DESCRIPTION
Done with mitigate tomcat-embed core from the repo, 
Done with test it by running omnibus on local run all the integration test case on local.
Also removed one extra suppression from suppression file of dependency check, which should not be there
Attached the latest report and screenshot of integration test cases
![image](https://user-images.githubusercontent.com/94971091/193822150-b8ff1c60-35aa-4244-afb1-8cbf3978ed9f.png)
![image](https://user-images.githubusercontent.com/94971091/193822171-468ebfff-5387-4aa1-ac70-7a7e0bdd7cff.png)

![image](https://user-images.githubusercontent.com/94971091/193822359-b85c5241-b969-4056-bcb5-86ddb38c838b.png)
