### PR TITLE
MItigate jackson databind version by updating to 2.13.4

### DIFF
--- a/cql-wih/pom.xml
+++ b/cql-wih/pom.xml
@@ -34,6 +34,7 @@
 		<mixpanel.version>1.4.4</mixpanel.version>
 		<org.json.version>20211205</org.json.version>
 		<sping-web.version>5.3.19</sping-web.version>
+		<jackson-databind.version>2.13.4</jackson-databind.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<dependencies>
@@ -299,7 +300,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.3</version>
+			<version>${jackson-databind.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<hibernate.version>5.4.24.Final</hibernate.version>
 		<spring.boot.starter.version>2.7.4</spring.boot.starter.version>
 		<spring.version>5.3.23</spring.version>
-		<jackson.version.databind>2.12.6.1</jackson.version.databind>
+		<jackson.version.databind>2.13.4</jackson.version.databind>
 		<jackson.version>2.12.6</jackson.version>
 		<protobuf-java.version>3.19.6</protobuf-java.version>
 		<mockito.version>2.23.0</mockito.version>


### PR DESCRIPTION
Done with updating version of jackson databind to 2.13.4,
Following versions get mitigate from report, 
jackson-databind-2.12.6.1.jar
jackson-databind-2.13.3.jar
jackson-databind-2.13.4.jar
but 2.13.4 is still available in report and jackson-databind-2.13.4 is latest version on maven report
Done with tested with by running with omnibus on local, 
![image](https://user-images.githubusercontent.com/94971091/194498953-271b37fe-c356-4a61-818b-131df7175f29.png)
![image](https://user-images.githubusercontent.com/94971091/194499437-9df0cd6a-e135-4cd3-8682-aa34b54c54f5.png)
![image](https://user-images.githubusercontent.com/94971091/194499454-16a1f89c-4d96-4aaf-9e41-fa9df7a93d1f.png)

