### PR TITLE
Mitigate jbpm-bpmn2 Vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<properties>
 		<base.version>0.0.9-SNAPSHOT</base.version>
 		<jdk.version>1.8</jdk.version>
-		<kie.version>7.71.0.Final</kie.version>
+		<kie.version>7.73.0.Final</kie.version>
 		<wb.kie.version>7.71.0.Final</wb.kie.version>
 		<junit.version>4.13.2</junit.version>
 		<hapi.fhir.version>5.6.0</hapi.fhir.version>


### PR DESCRIPTION
Done with mitigate jbpm-bpmn2 7.71.0.Final by updating version kie-server-api from 7.71.0.Final to 7.73.0.Final, But still latest version is available in the report,
Done with build and test it by running with omnibus on local, 
Run integration test cases on local

![image](https://user-images.githubusercontent.com/94971091/195309978-f8a5bf0f-f589-415d-b0d6-0c7e14ce08d6.png)
![image](https://user-images.githubusercontent.com/94971091/195310151-8ca84a09-1512-4c7d-a4f1-e2fe92038882.png)
