### PR TITLE
Mitigate jbpm bpmn2 vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<properties>
 		<base.version>0.0.9-SNAPSHOT</base.version>
 		<jdk.version>1.8</jdk.version>
-		<kie.version>7.71.0.Final</kie.version>
+		<kie.version>7.73.0.Final</kie.version>
 		<wb.kie.version>7.73.0.Final</wb.kie.version>
 		<junit.version>4.13.2</junit.version>
 		<hapi.fhir.version>5.6.0</hapi.fhir.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<base.version>0.0.9-SNAPSHOT</base.version>
 		<jdk.version>1.8</jdk.version>
 		<kie.version>7.71.0.Final</kie.version>
-		<wb.kie.version>7.71.0.Final</wb.kie.version>
+		<wb.kie.version>7.73.0.Final</wb.kie.version>
 		<junit.version>4.13.2</junit.version>
 		<hapi.fhir.version>5.6.0</hapi.fhir.version>
 		<hapi.fhir.utilities.version>5.5.7</hapi.fhir.utilities.version>

--- a/sql/A2D2.SQL
+++ b/sql/A2D2.SQL
@@ -1606,5 +1606,6 @@ create table TimerMappingInfo (
         primary key (id)
 );
 ALTER TABLE TimerMappingInfo ADD COLUMN info oid;
-
+ALTER TABLE TimerMappingInfo ADD COLUMN processInstanceId int8;
+ALTER TABLE TimerMappingInfo ALTER COLUMN timerId DROP NOT NULL;
 commit;

--- a/sql/A2D2_mysql.sql
+++ b/sql/A2D2_mysql.sql
@@ -1303,5 +1303,6 @@ create table TimerMappingInfo (
         primary key (id)
 );
 ALTER TABLE TimerMappingInfo ADD COLUMN info longblob;
-
+ALTER TABLE TimerMappingInfo ADD COLUMN processInstanceId bigint;
+ALTER TABLE TimerMappingInfo MODIFY timerId bigint NULL;
 commit;


### PR DESCRIPTION
Updated the version of kie from 7.71.0.final to 7.73.0.final,
Update the sql files which needs to be alter table

How it was tested
Test it by running it on local
Running the integration test cases and persitent integration test case pphtn program and pphtn-recommendation service by pointing local

