### PR TITLE
Mitigate sshd-common by updating version to  2.9.1

### DIFF
--- a/cds-hook-services/pom.xml
+++ b/cds-hook-services/pom.xml
@@ -255,6 +255,10 @@
 					<groupId>jakarta.transaction</groupId>
 					<artifactId>jakarta.transaction-api</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.sshd</groupId>
+					<artifactId>sshd-common</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
@@ -271,6 +275,11 @@
 		    <groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
 		    <version>${protobuf-java.version}</version>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.sshd</groupId>
+		    <artifactId>sshd-common</artifactId>
+		    <version>${sshd-common.version}</version>
 		</dependency>
 		<dependency>
 		    <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 		<httpcore.version>4.4.13</httpcore.version>
 		<gson.version>2.8.9</gson.version>
 		<maven.version>3.8.4</maven.version>
+		<sshd-common.version>2.9.1</sshd-common.version>
 		<log4j.version>2.17.1</log4j.version>
 		<junit-platform-commons.version>1.8.1</junit-platform-commons.version>
 		<apiguardian.version>1.1.2</apiguardian.version>


### PR DESCRIPTION
When we generate a dependency check report so, we found this vulnerable with 2.3.0 so update version to 2.9.1
Done with test it by running omnibus on local. Ran the integration test cases