### PR TITLE
Mitigate wildfly-elytron-audit@1.15.5.Final by updating version to 2.0.0

### DIFF
--- a/cds-hook-services/pom.xml
+++ b/cds-hook-services/pom.xml
@@ -259,7 +259,20 @@
 					<groupId>org.apache.sshd</groupId>
 					<artifactId>sshd-common</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.wildfly.security</groupId>
+					<artifactId>wildfly-elytron</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.sshd</groupId>
+					<artifactId>sshd-common</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>org.wildfly.security</groupId>
+		    <artifactId>wildfly-elytron</artifactId>
+		    <version>${wildfly-elytron.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.inject</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,13 @@
 		<httpcore.version>4.4.13</httpcore.version>
 		<gson.version>2.8.9</gson.version>
 		<maven.version>3.8.4</maven.version>
-		<sshd-common.version>2.9.1</sshd-common.version>
+		<sshd-common.version>2.7.0</sshd-common.version>
 		<log4j.version>2.17.1</log4j.version>
 		<junit-platform-commons.version>1.8.1</junit-platform-commons.version>
 		<apiguardian.version>1.1.2</apiguardian.version>
 		<netty.version>4.1.77.Final</netty.version>
 		<mixpanel.version>1.4.4</mixpanel.version>
+		<wildfly-elytron.version>2.0.0.Final</wildfly-elytron.version>
 		<org.json.version>20211205</org.json.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
When I generate a report found wildfly-elytron-audit@1.15.5
Done with mitigate wildfly-elytron-audit@1.15.5 by updating version to 2.0.0
Done with test it by running it with omnibus on local, and done with run all the integration test case on local

In this PR I down the version of sshd-common because, wildify using 2.7.0, and we have used latest, So, project is giving error while build, Its suggest to exclude or reduce the sshd-common version,
sshd-common-2.7.0 is not vulnerable.

![image](https://user-images.githubusercontent.com/94971091/199710725-39d2d7da-94b4-4984-9193-6f2f595d734f.png)
![image](https://user-images.githubusercontent.com/94971091/199710753-bff103ed-af52-4484-9e7c-23e36aa1444f.png)
