### PR TITLE
Mitigate aws-java sdk core by updating version

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -50,6 +50,9 @@
 		<kotlin-stdlib.version>1.6.21</kotlin-stdlib.version>
 		<okio.version>3.1.0</okio.version>
 		<okhttp.version>4.9.3</okhttp.version>
+		<aws-java-sdk.version>1.12.334</aws-java-sdk.version>
+		<joda-time.version>2.10.6</joda-time.version>
+		<cloudwatchlogbackappender.version>2.1</cloudwatchlogbackappender.version>
 		<mysql-connector-java.version>8.0.29</mysql-connector-java.version>	
 	</properties>
 
@@ -851,8 +854,23 @@
 		<dependency>
 			<groupId>com.j256.cloudwatchlogbackappender</groupId>
 			<artifactId>cloudwatchlogbackappender</artifactId>
-			<version>1.11</version>
+			<version>${cloudwatchlogbackappender.version}</version>
 			<exclusions>
+				<exclusion>
+					<groupId>com.amazonaws</groupId>
+					<artifactId>aws-java-sdk-logs</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.amazonaws</groupId>
+					<artifactId>aws-java-sdk-ec2</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>com.amazonaws</groupId>
+		    <artifactId>aws-java-sdk-logs</artifactId>
+		    <version>${aws-java-sdk.version}</version>
+		    <exclusions>
 				<exclusion>
 					<groupId>joda-time</groupId>
 					<artifactId>joda-time</artifactId>
@@ -860,6 +878,22 @@
 			</exclusions>
 		</dependency>
 
+		<dependency>
+		    <groupId>com.amazonaws</groupId>
+		    <artifactId>aws-java-sdk-ec2</artifactId>
+		    <version>${aws-java-sdk.version}</version>
+		    <exclusions>
+				<exclusion>
+					<groupId>joda-time</groupId>
+					<artifactId>joda-time</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>joda-time</groupId>
+		    <artifactId>joda-time</artifactId>
+		    <version>${joda-time.version}</version>
+		</dependency>				
 		<!--leave this for now as backward compatibility concerns, remove after 
 			fixing omnibus A2D2-584 -->
 		<dependency>

--- a/sms-wih/pom.xml
+++ b/sms-wih/pom.xml
@@ -27,6 +27,7 @@
 	<url>https://www.elimu.io</url>
 
 	<properties>
+		<twilio.version>7.55.0</twilio.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
@@ -69,7 +70,7 @@
 		<dependency>
 		  <groupId>com.twilio.sdk</groupId>
 		  <artifactId>twilio</artifactId>
-		  <version>7.52.0</version>
+		  <version>${twilio.version}</version>
 		  <exclusions>
 		  	<exclusion>
                    		<groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
When we generate a report,found it aws-java-sdk-core vulnerable by updating version from 1.10.40  to 1.12.334
Done with run it with omnibus and ran integration test cases by pointing omnibus local
Update the joda-time version, Update the twilio version, twilio and aws-java-sdk-core both using different version of joda-time,

![image](https://user-images.githubusercontent.com/94971091/199965035-efbe0553-6ce6-4083-856c-46faa4f0e0af.png)
![image](https://user-images.githubusercontent.com/94971091/199965072-f80a793f-5835-4b1d-a686-65569ff056bd.png)
![image](https://user-images.githubusercontent.com/94971091/199965141-f7d02b5d-5d98-40bf-9b31-56ecd1afcaed.png)
