### PR TITLE
Mitigate jackson databind by updating spring-boot

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -27,7 +27,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.4</version>
+		<version>2.7.5</version>
 		<relativePath />
 	</parent>
 

--- a/cds-hook-services/pom.xml
+++ b/cds-hook-services/pom.xml
@@ -34,7 +34,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-parent</artifactId>
-				<version>2.7.4</version>
+				<version>2.7.5</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
 		<json-simple.version>1.1.1</json-simple.version>
 		<h2.version>2.1.210</h2.version>
 		<hibernate.version>5.4.24.Final</hibernate.version>
-		<spring.boot.starter.version>2.7.4</spring.boot.starter.version>
+		<spring.boot.starter.version>2.7.5</spring.boot.starter.version>
 		<spring.version>5.3.23</spring.version>
-		<jackson.version.databind>2.13.4.1</jackson.version.databind>
+		<jackson.version.databind>2.13.4.2</jackson.version.databind>
 		<jackson.version>2.12.6</jackson.version>
 		<protobuf-java.version>3.19.6</protobuf-java.version>
 		<mockito.version>2.23.0</mockito.version>

--- a/service-daos/pom.xml
+++ b/service-daos/pom.xml
@@ -30,7 +30,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-parent</artifactId>
-				<version>2.7.4</version>
+				<version>2.7.5</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
When I generate report I found jackson databind vulnerable with high severity, Its coming from child of spring boot, Mitigate it by updating spring version and update the version which we are using keep same version as sping boot using internally,

![image](https://user-images.githubusercontent.com/94971091/200273036-0253cf1a-0ed5-4f0b-a0e2-27460e1c5c9a.png)
![image](https://user-images.githubusercontent.com/94971091/200273530-550df4ad-f1ff-443f-8bd7-d6279bba8b20.png)

![image](https://user-images.githubusercontent.com/94971091/200273634-25d46e3b-dad3-49d9-b6bc-fe615a364409.png)
