### PR TITLE
Mitigate tomcat embed core by updating version to 9.0.68

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -39,10 +39,10 @@
 		<jasypt.version>3.0.3</jasypt.version>
 		<commons-io.version>2.11.0</commons-io.version>
 		<maven.version>3.8.4</maven.version>
-		<tomcat-embed-websocket.version>9.0.65</tomcat-embed-websocket.version>
+		<tomcat-embed-websocket.version>9.0.68</tomcat-embed-websocket.version>
 		<spring.version>5.3.23</spring.version>
 		<resteasy-client.version>4.7.2.Final</resteasy-client.version>
-		<tomcat-embed-core.version>9.0.65</tomcat-embed-core.version>
+		<tomcat-embed-core.version>9.0.68</tomcat-embed-core.version>
 		<log4j.version>2.17.1</log4j.version>
 		<logback-classic.version>1.2.10</logback-classic.version>
 		<logback-core.version>1.2.9</logback-core.version>


### PR DESCRIPTION
When I generate a report I found tomcat-embed-core and tomcat-embed-websocker vulnerable with version 9.0.65. Update it to 9.0.68 to mitigate it, re-generate a report and its mitigate,
Run it with omnibus by updating tomcat version in omnibus, test all the integration test cases by pointing local,