### PR TITLE
Mitigate commons-text by updating version

### DIFF
--- a/cds-hook-services/pom.xml
+++ b/cds-hook-services/pom.xml
@@ -105,7 +105,16 @@
 					<groupId>org.apache.ant</groupId>
 					<artifactId>ant</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-text</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+		    <version>${commons-text.version}</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.apache.ant</groupId>

--- a/cdshooks-wih/pom.xml
+++ b/cdshooks-wih/pom.xml
@@ -65,7 +65,19 @@
     	<groupId>ca.uhn.hapi.fhir</groupId>
     	<artifactId>hapi-fhir-structures-dstu2</artifactId>
     	<scope>test</scope>
+    	<exclusions>
+    		<exclusion>
+    			<groupId>org.apache.commons</groupId>
+    			<artifactId>commons-text</artifactId>
+    		</exclusion>
+    	</exclusions>
     </dependency>
+    <dependency>
+	    <groupId>org.apache.commons</groupId>
+	    <artifactId>commons-text</artifactId>
+	    <version>${commons-text.version}</version>
+	    <scope>test</scope>
+	</dependency>
     <dependency>
     	<groupId>ca.uhn.hapi.fhir</groupId>
     	<artifactId>hapi-fhir-structures-dstu3</artifactId>

--- a/core-dependencies/datafetch-service/pom.xml
+++ b/core-dependencies/datafetch-service/pom.xml
@@ -51,7 +51,16 @@
 					<groupId>commons-codec</groupId>
 					<artifactId>commons-codec</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-text</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+		    <version>${commons-text.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>

--- a/core-dependencies/fhir-parse-util/pom.xml
+++ b/core-dependencies/fhir-parse-util/pom.xml
@@ -52,11 +52,21 @@
 					<groupId>commons-codec</groupId>
 					<artifactId>commons-codec</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-text</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+		    <version>${commons-text.version}</version>
+		    <scope>test</scope>
 		</dependency>	
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>

--- a/cql-wih/pom.xml
+++ b/cql-wih/pom.xml
@@ -157,8 +157,18 @@
 					<groupId>com.fasterxml.jackson.core</groupId>
 					<artifactId>jackson-databind</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-text</artifactId>
+				</exclusion>
 			</exclusions>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+		    <version>${commons-text.version}</version>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>

--- a/fhir-helpers/pom.xml
+++ b/fhir-helpers/pom.xml
@@ -28,6 +28,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<hapi.fhir.version>5.6.0</hapi.fhir.version>
 		<hapi.fhir.util.version>5.5.7</hapi.fhir.util.version>
+		<commons-text.version>1.10.0</commons-text.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -72,6 +73,17 @@
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-base</artifactId>
 			<version>${hapi.fhir.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-text</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+		    <version>${commons-text.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>

--- a/fhir-query-helper-base/pom.xml
+++ b/fhir-query-helper-base/pom.xml
@@ -134,9 +134,17 @@
 					<groupId>commons-codec</groupId>
    			 		<artifactId>commons-codec</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-text</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
-
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+		    <version>${commons-text.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>com.googlecode.json-simple</groupId>
 			<artifactId>json-simple</artifactId>

--- a/fhir-query-helper-dstu2/pom.xml
+++ b/fhir-query-helper-dstu2/pom.xml
@@ -38,6 +38,17 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-dstu2</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-text</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+		    <version>${commons-text.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/fhir-query-helper-dstu3/pom.xml
+++ b/fhir-query-helper-dstu3/pom.xml
@@ -55,7 +55,16 @@
 					<groupId>com.squareup.okhttp3</groupId>
 					<artifactId>okhttp</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-text</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+		    <version>${commons-text.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>

--- a/fhir-query-helper-r4/pom.xml
+++ b/fhir-query-helper-r4/pom.xml
@@ -44,7 +44,16 @@
 					<groupId>com.squareup.okhttp3</groupId>
 					<artifactId>okhttp</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-text</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+		    <version>${commons-text.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/fhir-resource-wih/pom.xml
+++ b/fhir-resource-wih/pom.xml
@@ -121,7 +121,17 @@
 					<groupId>commons-codec</groupId>
    			 		<artifactId>commons-codec</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-text</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+		    <version>${commons-text.version}</version>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>

--- a/ftl-transform-wih/pom.xml
+++ b/ftl-transform-wih/pom.xml
@@ -77,7 +77,17 @@
 					<groupId>commons-codec</groupId>
    			 		<artifactId>commons-codec</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-text</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+		    <version>${commons-text.version}</version>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.kie</groupId>

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -43,7 +43,17 @@
 					<groupId>com.squareup.okhttp3</groupId>
 					<artifactId>okhttp</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-text</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+		    <version>${commons-text.version}</version>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>

--- a/oauth-helpers/pom.xml
+++ b/oauth-helpers/pom.xml
@@ -93,6 +93,11 @@
 			</exclusions>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+		    <version>${commons-text.version}</version>
+		</dependency>
     		<dependency>
 			<groupId>org.mvel</groupId>
 			<artifactId>mvel2</artifactId>
@@ -107,6 +112,10 @@
 				<exclusion>
 					<groupId>com.squareup.okhttp3</groupId>
 					<artifactId>okhttp</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-text</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
 		<mixpanel.version>1.4.4</mixpanel.version>
 		<wildfly-elytron.version>2.0.0.Final</wildfly-elytron.version>
 		<org.json.version>20211205</org.json.version>
+		<commons-text.version>1.10.0</commons-text.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<kotlin-stdlib.version>1.6.20</kotlin-stdlib.version>

--- a/task-utilities/pom.xml
+++ b/task-utilities/pom.xml
@@ -16,6 +16,7 @@
 		<freemarker.version>2.3.30</freemarker.version>
 		<maven.version>3.8.4</maven.version>
 		<jsoup.version>1.15.3</jsoup.version>
+		<commons-text.version>1.10.0</commons-text.version>
 		<protobuf-java.version>3.19.6</protobuf-java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -196,7 +197,17 @@
 					<groupId>com.google.guava</groupId>
 					<artifactId>guava</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-text</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+		    <version>${commons-text.version}</version>
+		    <scope>test</scope>
 		</dependency>
 	</dependencies>
 	<distributionManagement>


### PR DESCRIPTION
Done with mitigate commons-text by exclude and added manually with updated version,
I try with update parent hapi-fhir to mitigate it, but its giving too much conflict its still available in the report from kie-based-services,
Mitigate it and ran it with omnibus by running on local..