### PR TITLE
Add dependency-check suppression for spring-web 5.3.23

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -2,6 +2,13 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
    <suppress>
       <notes><![CDATA[
+      file name: spring-web-5.3.23.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
+      <cve>CVE-2016-1000027</cve>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
       file name: maven-core-3.3.9.jar
       False Positive: We use our own repository manager to govern the repositories used by our builds
       ]]></notes>


### PR DESCRIPTION
Adding a suppression for this.

This vulnerability is not listed on mvnrepository [here](https://mvnrepository.com/artifact/org.springframework/spring-web/5.3.23).

The vulnerability cannot be mitigated by updating the dependency and Spring Boot will not be updated to resolve this. I’ve highlighted the reason below:

Pivotal Spring Framework through 5.3.16 suffers from a potential remote code execution (RCE) issue if used for Java deserialization of untrusted data. Depending on how the library is implemented within a product, this issue may or not occur, and authentication may be required. NOTE: the vendor's position is that untrusted data is not an intended use case. The product's behavior will not be changed because some users rely on deserialization of trusted data.

Ref: https://nvd.nist.gov/vuln/detail/CVE-2016-1000027