### PR TITLE
Add dependency-check suppression for spring-security-crypto

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -2,6 +2,13 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
    <suppress>
       <notes><![CDATA[
+      file name: spring-security-crypto-5.7.5.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
+      <vulnerabilityName>CVE-2020-5408</vulnerabilityName>
+   </suppress>   
+   <suppress>
+      <notes><![CDATA[
       file name: maven-core-3.3.9.jar
       False Positive: We use our own repository manager to govern the repositories used by our builds
       ]]></notes>


### PR DESCRIPTION
This is a false positive and I’m going to add a suppression for it. The [mvnrepository.com](http://mvnrepository.com/) site shows no vulnerabilities in this version and the CVE (description below) mentions other/older versions.

Spring Security versions 5.3.x prior to 5.3.2, 5.2.x prior to 5.2.4, 5.1.x prior to 5.1.10, 5.0.x prior to 5.0.16 and 4.2.x prior to 4.2.16 use a fixed null initialization vector with CBC Mode in the implementation of the queryable text encryptor. A malicious user with access to the data that has been encrypted using such an encryptor may be able to derive the unencrypted values using a dictionary attack.

Ref: https://nvd.nist.gov/vuln/detail/CVE-2020-5408