### PR TITLE
Mitigate Protobuf-java by updating version to 3.21.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<spring.version>5.3.23</spring.version>
 		<jackson.version.databind>2.13.4.2</jackson.version.databind>
 		<jackson.version>2.12.6</jackson.version>
-		<protobuf-java.version>3.19.6</protobuf-java.version>
+		<protobuf-java.version>3.21.8</protobuf-java.version>
 		<mockito.version>2.23.0</mockito.version>
 		<jedis.version>4.0.1</jedis.version>
 		<cds.helper.version>0.0.13</cds.helper.version>
@@ -635,7 +635,7 @@
 			<plugin>
 				<groupId>org.owasp</groupId>
 				<artifactId>dependency-check-maven</artifactId>
-				<version>7.2.1</version>
+				<version>7.3.0</version>
 				<configuration>
 					<skipProvidedScope>true</skipProvidedScope>
 					<skipRuntimeScope>true</skipRuntimeScope>

--- a/task-utilities/pom.xml
+++ b/task-utilities/pom.xml
@@ -17,7 +17,7 @@
 		<maven.version>3.8.4</maven.version>
 		<jsoup.version>1.15.3</jsoup.version>
 		<commons-text.version>1.10.0</commons-text.version>
-		<protobuf-java.version>3.19.6</protobuf-java.version>
+		<protobuf-java.version>3.21.8</protobuf-java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>


### PR DESCRIPTION
When I generate a report I found protobuf-java is vulnerable with version 3.19.6 and update version to 3.21.8.
Done with mitigate it and test it with by running on local, Done with test it by running unit test case and integration test cases on local.
![image_2022_11_15T14_44_21_347Z](https://user-images.githubusercontent.com/94971091/202119356-a3e60d84-1095-4772-839b-6def1ad332a2.png)
![image_2022_11_15T14_44_10_426Z](https://user-images.githubusercontent.com/94971091/202119363-5e1b897b-eec4-4d80-843a-8053be435afe.png)
![image_2022_11_15T14_43_55_866Z](https://user-images.githubusercontent.com/94971091/202119365-05fa4372-2719-4519-8d40-a8723c0e5c63.png)
