### PR TITLE
Mitigate JBPM-BPMN2 in by doing suppression

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -120,4 +120,11 @@
       <packageUrl regex="true">^pkg:maven/org\.apache\.poi/poi\-ooxml\-schemas@.*$</packageUrl>
       <cve>CVE-2022-26336</cve>
    </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: jbpm-bpmn2-7.73.0.Final.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.jbpm/jbpm\-bpmn2@.*$</packageUrl>
+      <vulnerabilityName>CVE-2019-14839</vulnerabilityName>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
When I generate a report I found JBPM-BPM2 is vulnerable with latest version 7.73.0.final, The reason behind suppression is we are not using JBPM-BPM2 library for login into business centre console. We are using other services and models of JBPM-BPM2.


