### PR TITLE
Adds suppression for vulnerability wildfly-elytron

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -120,4 +120,11 @@
       <packageUrl regex="true">^pkg:maven/org\.jbpm/jbpm\-bpmn2@.*$</packageUrl>
       <vulnerabilityName>CVE-2019-14839</vulnerabilityName>
    </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: wildfly-elytron-2.0.0.Final.jar (shaded: org.apache.sshd:sshd-common:2.7.0)
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.apache\.sshd/sshd\-common@.*$</packageUrl>
+      <cve>CVE-2022-45047</cve>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
This vulnerability is comming from sshd-core (https://mvnrepository.com/artifact/org.apache.sshd/sshd-core), since we are not using Apache MINA SSHD (sshd-core),instead we are using sshd-common, we are not vulnerable to this hence adding suppression for it.