### PR TITLE
Adds suppression for snakeyaml vulnerability

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -90,8 +90,8 @@
       file name: snakeyaml-1.33.jar
       ]]></notes>
       <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-      <vulnerabilityName>CVE-2022-41854</vulnerabilityName>
-   </suppress>   
+      <vulnerabilityName>CVE-2022-1471</vulnerabilityName>
+   </suppress>
    <suppress>
       <notes><![CDATA[
       file name: wildfly-elytron-2.0.0.Final.jar (shaded: com.fasterxml.jackson.core:jackson-databind:2.13.3)


### PR DESCRIPTION
I have remove old suppression cve from the owasp-dependency-check-report and in the report we found new one cve in a2d2 dependency check report and Added suppression for itv,

CVE-2022-1471 (OSSINDEX)
SnakeYaml's Constructor() class does not restrict types which can be instantiated during deserialization. Deserializing yaml content provided by an attacker can lead to remote code execution. We recommend using SnakeYaml's SafeConsturctor when parsing untrusted content to restrict deserialization.

[NVD - CVE-2022-1471](https://nvd.nist.gov/vuln/detail/CVE-2022-1471)

We are not using a reference of SnakeYaml's Constructor() in a2d2, So, we can suppress it, by removing old suppression.

![image](https://user-images.githubusercontent.com/94971091/205902928-c54380fa-a79e-45d3-805d-d4492b999a1e.png)
