### PR TITLE
Removing h2-database to mitigate we not found any usage of it

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -658,11 +658,6 @@
 		    	</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<version>2.1.210</version>
-		</dependency>
-		<dependency>
 		    	<groupId>org.springframework</groupId>
 		    	<artifactId>spring-tx</artifactId>
 		    	<version>${spring.version}</version>

--- a/cds-hook-services/pom.xml
+++ b/cds-hook-services/pom.xml
@@ -421,11 +421,6 @@
 			<version>2.1.4</version>
 		</dependency>
 		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-entitymanager</artifactId>
 			<exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
 		<hapi.fhir.version>5.6.0</hapi.fhir.version>
 		<hapi.fhir.utilities.version>5.5.7</hapi.fhir.utilities.version>
 		<json-simple.version>1.1.1</json-simple.version>
-		<h2.version>2.1.210</h2.version>
 		<hibernate.version>5.4.24.Final</hibernate.version>
 		<spring.boot.starter.version>2.7.5</spring.boot.starter.version>
 		<spring.version>5.3.23</spring.version>

--- a/service-daos/pom.xml
+++ b/service-daos/pom.xml
@@ -78,11 +78,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<scope>test</scope>
-		</dependency>
 		<!-- spring-test, hamcrest, ... -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
When i generate a dependency check report I found it vulnerable, I Updated it to latest version but it still available in report, its asking for suppression, Then we can suppress it or not, So, I found any usage in a2d2,
So, directly remove and did testing by running omnibus on local.
Done with test it properly on local.
