### PR TITLE
Retry mechanishms added

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -326,7 +326,7 @@
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>
 			<artifactId>generic-helpers</artifactId>
-			<version>0.0.13</version>
+			<version>0.0.14</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- web development, including Tomcat and spring-webmvc -->

--- a/core-wih/src/main/java/io/elimu/a2d2/corewih/ServiceRestAPIDelegate.java
+++ b/core-wih/src/main/java/io/elimu/a2d2/corewih/ServiceRestAPIDelegate.java
@@ -49,6 +49,7 @@ public class ServiceRestAPIDelegate implements WorkItemHandler {
 	private static final String HEADER_VALUE_PARAM = "header_value_";
 	private static final String BODY_VALUE_PARAM = "body_value_";
 	private static final String PARAM_VALUE_PARAM = "param_value_";
+	private static final String RETRIES_PARAM = "retries";
 	private static final String SERVICE_RESPONSE = "serviceResponse";
 	private static final String STRICT_REDIRECT_PARAM = "strictRedirect";
 
@@ -79,6 +80,13 @@ public class ServiceRestAPIDelegate implements WorkItemHandler {
 			ClientRequest clientRequest = (ClientRequest) workItem.getParameter(CLIENT_REQUEST);
 			HttpMethod method = getMethod(workItem);
 
+			int retries = Integer.valueOf(System.getProperty("http.invoke.retries", "3"));
+			int delay = Integer.valueOf(System.getProperty("http.invoke.retrydelay", "5000"));
+			String sRetries = String.valueOf(workItem.getParameter(RETRIES_PARAM));
+			if (sRetries != null && !"null".equals(sRetries)) {
+				retries = Integer.valueOf(sRetries);
+			}
+			
 			if(method == null) {
 				logger.debug("method is null");
 				throw new WorkItemHandlerException("Service Request method is null");
@@ -128,36 +136,46 @@ public class ServiceRestAPIDelegate implements WorkItemHandler {
 			HttpEntity<?> entity = new HttpEntity<>(body, headers);
 			logger.debug("Prepared http entity");
 			ResponseEntity<?> response = null;
-			try {
-				response = restTemplate.exchange(url + parameter,
-					method,
-					entity,
-					String.class);
-				logger.debug("Received response");
-			} catch (RestManageException rme) {
-				logger.warn("We had an error (code: " + rme.getStatusCode()+ ") when invoking the url " + url + ".", rme.getMessage());
-				ServiceResponse resp = new ServiceResponse();
-				resp.setResponseCode(rme.getStatusCode());
-				resp.setBody(rme.getMessage());			
-				resp.addHeaderValue("ErrorMessage", rme.getStatusText());
-				workItemResult.put(SERVICE_RESPONSE, resp);
-				manager.completeWorkItem(workItem.getId(), workItemResult);
-				return;
-			} catch (Exception ex2) {
-				logger.warn("We had an error when invoking the url " + url, ex2);
-				ServiceResponse resp = new ServiceResponse();
-				resp.setBody(ex2.getMessage());
-				resp.setResponseCode(500);
-				resp.addHeaderValue("ErrorMessage", ex2.getMessage());
-				workItemResult.put(SERVICE_RESPONSE, resp);
-				manager.completeWorkItem(workItem.getId(), workItemResult);
-				return;
+			boolean success = false;
+			int count = 0;
+			while (count < retries && !success) {
+				try {
+					response = restTemplate.exchange(url + parameter,
+						method,
+						entity,
+						String.class);
+					logger.debug("Received response");
+					ServiceResponse serviceResponse = createServiceResponse(response);
+					logger.trace("Body received is " + response.getBody());
+					logger.trace("Code reason received is " + response.getStatusCode().getReasonPhrase());
+					workItemResult.put(SERVICE_RESPONSE, serviceResponse);
+					if (response.getStatusCodeValue() < 500) {
+						success = true;
+					} else {
+						count++;
+						logger.warn("We had a return status code" + response.getStatusCodeValue() + "so we will retry (this was attempt " + count + ")");
+					}
+				} catch (RestManageException rme) {
+					count++;
+					logger.warn("We had an error (code: " + rme.getStatusCode()+ ") when invoking the url " + url + ".", rme.getMessage());
+					ServiceResponse resp = new ServiceResponse();
+					resp.setResponseCode(rme.getStatusCode());
+					resp.setBody(rme.getMessage());			
+					resp.addHeaderValue("ErrorMessage", rme.getStatusText());
+					workItemResult.put(SERVICE_RESPONSE, resp);
+					Thread.sleep(delay * count);
+				} catch (Exception ex2) {
+					count++;
+					logger.warn("We had an error when invoking the url " + url, ex2);
+					ServiceResponse resp = new ServiceResponse();
+					resp.setBody(ex2.getMessage());
+					resp.setResponseCode(500);
+					resp.addHeaderValue("ErrorMessage", ex2.getMessage());
+					workItemResult.put(SERVICE_RESPONSE, resp);
+					Thread.sleep(delay * count);
+				}
 			}
 
-			ServiceResponse serviceResponse = createServiceResponse(response);
-			logger.trace("Body received is " + response.getBody());
-			logger.trace("Code reason received is " + response.getStatusCode().getReasonPhrase());
-			workItemResult.put(SERVICE_RESPONSE, serviceResponse);
 			manager.completeWorkItem(workItem.getId(), workItemResult);
 
 			logger.trace("Service Rest API completed for   " + url );

--- a/core-wih/src/main/java/io/elimu/a2d2/rulewih/DmnInvokeDelegate.java
+++ b/core-wih/src/main/java/io/elimu/a2d2/rulewih/DmnInvokeDelegate.java
@@ -38,8 +38,9 @@ public class DmnInvokeDelegate implements WorkItemHandler {
 	@Override
 	public void executeWorkItem(WorkItem workItem, WorkItemManager manager) {
 		Map<String, Object> results = workItem.getResults();
+		KieSession ksession = kbase.newKieSession(null, env);
 		try {
-			DMNRuntime runtime = kbase.newKieSession(null, env).getKieRuntime(DMNRuntime.class);
+			DMNRuntime runtime = ksession.getKieRuntime(DMNRuntime.class);
 			DMNContext context = DMNFactory.newContext();
 			for (Map.Entry<String, Object> entry : workItem.getParameters().entrySet()) {
 				if (entry.getKey().startsWith("dmninput_")) {
@@ -84,6 +85,8 @@ public class DmnInvokeDelegate implements WorkItemHandler {
 		} catch (Exception e) {
 			results.put("exception", e);
 			manager.completeWorkItem(workItem.getId(), results);
+		} finally {
+			ksession.dispose();
 		}
 	}
 

--- a/fhir-helpers/pom.xml
+++ b/fhir-helpers/pom.xml
@@ -20,7 +20,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.elimu.a2d2</groupId>
 	<artifactId>fhir-helpers</artifactId>
-	<version>0.0.13</version>
+	<version>0.0.14</version>
 	<packaging>jar</packaging>
 	<name>fhir-helpers</name>
 	<url>http://maven.apache.org</url>

--- a/fhir-query-helper-base/pom.xml
+++ b/fhir-query-helper-base/pom.xml
@@ -27,7 +27,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-base</artifactId>
-	<version>0.0.13</version>
+	<version>0.0.14</version>
 	<description>CDS Helper base</description>
 
 	<properties>

--- a/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/helper/FetchCallRetry.java
+++ b/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/helper/FetchCallRetry.java
@@ -25,7 +25,7 @@ public class FetchCallRetry<T> {
 		while (count < retries && !success) {
 			try {
 				if (count > 0) {
-					Thread.sleep(delay * count);
+					Thread.sleep(getDelay(count, delay));
 				}
 				T retval = function.apply(null);
 				if (client.getTracker().getResponseStatusCode() < 500) {
@@ -40,5 +40,14 @@ public class FetchCallRetry<T> {
 			}
 		}
 		throw new RuntimeException("After " + count + " retries, invocation of clal still failed");
+	}
+
+	public int getDelay(int count, int delay) {
+		if (count == 2) {
+			delay *= 3;
+		} else if (count >= 3) {
+			delay *= 5;
+		}
+		return delay;
 	}
 }

--- a/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/helper/FetchCallRetry.java
+++ b/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/helper/FetchCallRetry.java
@@ -1,0 +1,44 @@
+package io.elimu.a2d2.cds.fhir.helper;
+
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FetchCallRetry<T> {
+
+	private static final Logger log = LoggerFactory.getLogger(FetchCallRetry.class);
+	
+	private Function<Object, T> function;
+	private QueryBuilder builder;
+
+	public FetchCallRetry(QueryBuilder builder, Function<Object, T> function) {
+		this.builder = builder;
+		this.function = function;
+	}
+
+	public T retryRestCall(FhirClientWrapper client) {
+		int retries = builder.getRetries();
+		int delay = builder.getDelay();
+		int count = 0;
+		boolean success = false;
+		while (count < retries && !success) {
+			try {
+				if (count > 0) {
+					Thread.sleep(delay * count);
+				}
+				T retval = function.apply(null);
+				if (client.getTracker().getResponseStatusCode() < 500) {
+					success = true;
+					return retval;
+				}
+				log.info("FHIR REST call failed attempt number " + count + " with status " + client.getTracker().getResponseStatusCode() + ". Retrying after waiting " + (delay * count) + "ms");
+				count++;
+			} catch (Throwable t) {
+				count++; // and retry
+				log.warn("FHIR REST call failed attempt number " + count + " with status " + client.getTracker().getResponseStatusCode() + " and error. Retrying after waiting " + (delay * count) + "ms", t);
+			}
+		}
+		throw new RuntimeException("After " + count + " retries, invocation of clal still failed");
+	}
+}

--- a/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/helper/FhirClientWrapper.java
+++ b/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/helper/FhirClientWrapper.java
@@ -28,6 +28,7 @@ public class FhirClientWrapper {
 	
 	private final IGenericClient wrap;
 	private boolean inUse = false;
+	private RequestDataInterceptor tracker;
 	
 	public FhirClientWrapper(IGenericClient client) {
 		this.wrap = client;
@@ -43,10 +44,20 @@ public class FhirClientWrapper {
 
 	public void registerInterceptor(IClientInterceptor theInterceptor) {
 		wrap.registerInterceptor(theInterceptor);
+		if (theInterceptor instanceof RequestDataInterceptor) {
+			this.tracker = (RequestDataInterceptor) theInterceptor;
+		}
 	}
 
 	public void unregisterInterceptor(IClientInterceptor theInterceptor) {
 		wrap.unregisterInterceptor(theInterceptor);
+		if (theInterceptor instanceof RequestDataInterceptor) {
+			this.tracker = null;
+		}
+	}
+
+	public RequestDataInterceptor getTracker() {
+		return tracker;
 	}
 
 	public IGenericClient unwrap() {

--- a/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/helper/QueryBuilder.java
+++ b/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/helper/QueryBuilder.java
@@ -12,7 +12,7 @@ public class QueryBuilder {
 	private int count;
 	private boolean useCache = true;
 	private int retries = Integer.valueOf(System.getProperty("http.invoke.retries", "3"));
-	private int delay = Integer.valueOf(System.getProperty("http.invoke.retrydelay", "5000"));
+	private int delay = Integer.valueOf(System.getProperty("http.invoke.retrydelay", "1000"));
 	
 	public QueryBuilder withRetries(int retries) {
 		this.retries = retries;

--- a/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/helper/QueryBuilder.java
+++ b/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/helper/QueryBuilder.java
@@ -11,6 +11,18 @@ public class QueryBuilder {
 	private String resourceType;
 	private int count;
 	private boolean useCache = true;
+	private int retries = Integer.valueOf(System.getProperty("http.invoke.retries", "3"));
+	private int delay = Integer.valueOf(System.getProperty("http.invoke.retrydelay", "5000"));
+	
+	public QueryBuilder withRetries(int retries) {
+		this.retries = retries;
+		return this;
+	}
+	
+	public QueryBuilder withDelayBetweenRetries(int delay) {
+		this.delay = delay;
+		return this;
+	}
 	
 	public QueryBuilder paging(boolean paging) {
 		this.paging = paging;
@@ -62,6 +74,14 @@ public class QueryBuilder {
 		return useCache;
 	}
 	
+	public int getDelay() {
+		return delay;
+	}
+	
+	public int getRetries() {
+		return retries;
+	}
+	
 	public String buildQuery(String baseUrl) {
 		StringBuilder sb = new StringBuilder();
 		sb.append(baseUrl).append('/').append(resourceType);
@@ -81,5 +101,57 @@ public class QueryBuilder {
 			}
 		}
 		return sb.toString();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + count;
+		result = prime * result + delay;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + (paging ? 1231 : 1237);
+		result = prime * result + ((params == null) ? 0 : params.hashCode());
+		result = prime * result + ((resourceType == null) ? 0 : resourceType.hashCode());
+		result = prime * result + retries;
+		result = prime * result + (useCache ? 1231 : 1237);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		QueryBuilder other = (QueryBuilder) obj;
+		if (count != other.count)
+			return false;
+		if (delay != other.delay)
+			return false;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (paging != other.paging)
+			return false;
+		if (params == null) {
+			if (other.params != null)
+				return false;
+		} else if (!params.equals(other.params))
+			return false;
+		if (resourceType == null) {
+			if (other.resourceType != null)
+				return false;
+		} else if (!resourceType.equals(other.resourceType))
+			return false;
+		if (retries != other.retries)
+			return false;
+		if (useCache != other.useCache)
+			return false;
+		return true;
 	}
 }

--- a/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/helper/QueryingServerHelperBase.java
+++ b/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/helper/QueryingServerHelperBase.java
@@ -429,7 +429,7 @@ public abstract class QueryingServerHelperBase<T, U extends IBaseResource> imple
 			if (!avoidCache.get().booleanValue() && cacheService!= null && cacheService.containsKey(cacheKey)) {
 				retval = (FhirResponse<IBaseResource>) cacheService.get(cacheKey).getValue();
 			} else {
-				retval = getResourceList(resourceType, resourceQuery, usePath, true);
+				retval = getResourceList(resourceType, resourceQuery, usePath, new QueryBuilder().paging(true));
 				if(!avoidCache.get().booleanValue() && cacheService!= null && CacheUtil.isValidState(retval.getResponseStatusCode())) {
 					cacheService.put(cacheKey, new ResponseEvent<>(retval, RESPONSE_EVENT_TIMEOUT));
 				}
@@ -443,7 +443,7 @@ public abstract class QueryingServerHelperBase<T, U extends IBaseResource> imple
 		return new FhirResponse<>(null, -1, "not invoked");
 	}
 	
-	private FhirResponse<IBaseResource> getResourceList(String resourceType, String resourceQuery, boolean usePath, boolean paging) {
+	private FhirResponse<IBaseResource> getResourceList(String resourceType, String resourceQuery, boolean usePath, QueryBuilder qb) {
 		FhirResponse<List<IBaseResource>> resourceList = null;
 		if (ctx.getVersion().getVersion().equals(this.fhirVersionEnum)) {
 			if (usePath) {
@@ -451,7 +451,7 @@ public abstract class QueryingServerHelperBase<T, U extends IBaseResource> imple
 				List<IBaseResource> result = resp == null || resp.getResult() == null ? null : Arrays.asList(resp.getResult());
 				resourceList = new FhirResponse<List<IBaseResource>>(result, resp.getResponseStatusCode(), resp.getResponseStatusInfo());
 			} else {
-				resourceList = queryServer(resourceQuery, paging);
+				resourceList = queryServer(resourceQuery, qb);
 			}
 		}
 		if(resourceList != null) {
@@ -467,7 +467,7 @@ public abstract class QueryingServerHelperBase<T, U extends IBaseResource> imple
 		}
 	}
 
-	protected FhirResponse<List<IBaseResource>> getRetVal(String resourceQuery, FhirVersionEnum fhirVersion, boolean paging) {
+	protected FhirResponse<List<IBaseResource>> getRetVal(String resourceQuery, FhirVersionEnum fhirVersion, QueryBuilder qb) {
 		FhirResponse<List<IBaseResource>> retval = null;
 		String cacheKey = CacheUtil.getCacheKey(resourceQuery, interceptors);
 
@@ -475,7 +475,7 @@ public abstract class QueryingServerHelperBase<T, U extends IBaseResource> imple
 			retval = (FhirResponse<List<IBaseResource>>) cacheService.get(cacheKey).getValue();
 		} else {
 			if (ctx.getVersion().getVersion().equals(fhirVersion)) {
-				retval = queryServer(resourceQuery, paging);
+				retval = queryServer(resourceQuery, qb);
 			}
 			if (!avoidCache.get().booleanValue() && cacheService != null && retval != null
 					&& CacheUtil.isValidState(retval.getResponseStatusCode())) {
@@ -521,7 +521,7 @@ public abstract class QueryingServerHelperBase<T, U extends IBaseResource> imple
 		try {
 			PerformanceHelper.getInstance().beginClock(QUERYINGSERVERHELPER, "queryResources");
 			String resourceQuery = this.getResourceQuery(resourceType, subjectId, subjectRefAttribute, fhirQuery);
-			return (resourceQuery == null) ? null : getRetVal(resourceQuery, this.fhirVersionEnum, true);
+			return (resourceQuery == null) ? null : getRetVal(resourceQuery, this.fhirVersionEnum, new QueryBuilder().paging(true));
 		} catch (Exception e) {
 			log.error( ERROR_MSG + e.getMessage() + ". [" + e.getClass().getName() + "]");
 		} finally {
@@ -544,7 +544,7 @@ public abstract class QueryingServerHelperBase<T, U extends IBaseResource> imple
 			}
 			PerformanceHelper.getInstance().beginClock(QUERYINGSERVERHELPER, "queryResources");
 			String resourceQuery = builder.buildQuery(fhirUrl);
-			return (resourceQuery == null) ? null : getRetVal(resourceQuery, this.fhirVersionEnum, builder.hasPaging());
+			return (resourceQuery == null) ? null : getRetVal(resourceQuery, this.fhirVersionEnum, builder);
 		} catch (Exception e) {
 			log.error( ERROR_MSG + e.getMessage() + ". [" + e.getClass().getName() + "]");
 		} finally {
@@ -625,7 +625,7 @@ public abstract class QueryingServerHelperBase<T, U extends IBaseResource> imple
 		factory.setServerValidationMode(ServerValidationModeEnum.NEVER);
 	}
 
-	public abstract FhirResponse<List<IBaseResource>> queryServer(String resourceQuery, boolean paging);
+	public abstract FhirResponse<List<IBaseResource>> queryServer(String resourceQuery, QueryBuilder builder);
 
 	public abstract FhirResponse<IBaseResource> fetchServer(final String resourceType, String resourceQuery);
 	

--- a/fhir-query-helper-dstu2/pom.xml
+++ b/fhir-query-helper-dstu2/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-dstu2</artifactId>
-	<version>0.0.13</version>
+	<version>0.0.14</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper</description>
 

--- a/fhir-query-helper-dstu2/src/test/java/io/elimu/a2d2/cds/fhir/cache/test/QueryingServerHelperCacheTest.java
+++ b/fhir-query-helper-dstu2/src/test/java/io/elimu/a2d2/cds/fhir/cache/test/QueryingServerHelperCacheTest.java
@@ -14,20 +14,23 @@
 
 package io.elimu.a2d2.cds.fhir.cache.test;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import ca.uhn.fhir.model.dstu2.resource.StructureDefinition;
 import io.elimu.a2d2.cds.fhir.cache.CacheUtil;
 import io.elimu.a2d2.cds.fhir.helper.FhirResponse;
+import io.elimu.a2d2.cds.fhir.helper.QueryBuilder;
 import io.elimu.a2d2.cds.fhir.helper.QueryingServerHelper;
 
 @SuppressWarnings("static-access")
@@ -86,13 +89,13 @@ public class QueryingServerHelperCacheTest {
 
 
 		doReturn(resourceQuery_1).when(queryingServerHelper).getResourceQuery(resourceType_1, subjectId_1, subjectRefAttribute_1, fhirQuery_1);
-		doReturn(retval_1).when(queryingServerHelper).queryServer(resourceQuery_1, true);
+		doReturn(retval_1).when(queryingServerHelper).queryServer(eq(resourceQuery_1), eq(new QueryBuilder().paging(true)));
 
 		doReturn(resourceQuery_2).when(queryingServerHelper).getResourceQuery(resourceType_2, subjectId_2, subjectRefAttribute_2, fhirQuery_2);
-		doReturn(retval_2).when(queryingServerHelper).queryServer(resourceQuery_2, true);
+		doReturn(retval_2).when(queryingServerHelper).queryServer(eq(resourceQuery_2), eq(new QueryBuilder().paging(true)));
 
 		doReturn(resourceQuery_3).when(queryingServerHelper).getResourceQuery(resourceType_3, subjectId_3, subjectRefAttribute_3, fhirQuery_3);
-		doReturn(retval_3).when(queryingServerHelper).queryServer(resourceQuery_3, true);
+		doReturn(retval_3).when(queryingServerHelper).queryServer(eq(resourceQuery_3), eq(new QueryBuilder().paging(true)));
 	}
 
 	@Test

--- a/fhir-query-helper-dstu2/src/test/java/io/elimu/a2d2/cds/fhir/helper/test/QueryingServerHelperTest.java
+++ b/fhir-query-helper-dstu2/src/test/java/io/elimu/a2d2/cds/fhir/helper/test/QueryingServerHelperTest.java
@@ -15,6 +15,7 @@
 package io.elimu.a2d2.cds.fhir.helper.test;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -100,8 +101,10 @@ public class QueryingServerHelperTest {
 	
 	@Test
 	public void testQueryBuilder() {
-		doReturn(fhirResponse).when(queryingServerHelper).queryServer(FHIR2_URL + "/Patient?_count=1&_sort=-_lastUpdated", false);
-		doReturn(fhirResponse).when(queryingServerHelper).queryServer(FHIR2_URL + "/Observation?_count=2&_sort=-date", true);
+		doReturn(fhirResponse).when(queryingServerHelper).queryServer(eq(FHIR2_URL + "/Patient?_count=1&_sort=-_lastUpdated"), 
+				eq(new QueryBuilder().resourceType("Patient").count(1).withParam("_sort", "-_lastUpdated").paging(false)));
+		doReturn(fhirResponse).when(queryingServerHelper).queryServer(eq(FHIR2_URL + "/Observation?_count=2&_sort=-date"), 
+				eq(new QueryBuilder().paging(true).resourceType("Observation").count(2).withParam("_sort", "-date")));
 		FhirResponse<List<IBaseResource>> retval = queryingServerHelper.query(
 					new QueryBuilder().resourceType("Patient").
 					count(1).withParam("_sort", "-_lastUpdated").paging(false));
@@ -120,7 +123,7 @@ public class QueryingServerHelperTest {
 	
 	@Test
 	public void fhirQueryAsync() {
-		doReturn(fhirResponse).when(queryingServerHelper).queryServer(any(), anyBoolean());
+		doReturn(fhirResponse).when(queryingServerHelper).queryServer(any(), any());
 		doReturn(fhirResponseObservation).when(queryingServerHelper).getResourceByIdResponse(any(), any());
 		long from = System.currentTimeMillis();
 		FhirFuture<FhirResponse<List<IBaseResource>>> f = queryingServerHelper.queryResourcesAsync("Observation",
@@ -141,7 +144,7 @@ public class QueryingServerHelperTest {
 
 	@Test
 	public void fhirQueryNoAuth() {
-		doReturn(fhirResponse).when(queryingServerHelper).queryServer(any(), anyBoolean());
+		doReturn(fhirResponse).when(queryingServerHelper).queryServer(any(), any());
 		QueryingServerHelper qshNoAuth = new QueryingServerHelper("http://testURL/baseDstu2");
 		Assert.assertNotNull(qshNoAuth);
 		FhirResponse<List<IBaseResource>> iResourceList = queryingServerHelper.queryResourcesResponse("Observation",
@@ -151,7 +154,7 @@ public class QueryingServerHelperTest {
 
 	@Test
 	public void fhirQueryAndQueryPartTest() {
-		doReturn(fhirResponse).when(queryingServerHelper).queryServer(any(), anyBoolean());
+		doReturn(fhirResponse).when(queryingServerHelper).queryServer(any(), any());
 		FhirResponse<List<IBaseResource>> iResourceList = queryingServerHelper.queryResourcesResponse("Observation",patient.getId().getIdPart(), null, IDENTIFIER);
 		Assert.assertNotNull(iResourceList);
 		doReturn(fhirResponsePatient).when(queryingServerHelper).getResourceByIdResponse(any(), any());
@@ -161,7 +164,7 @@ public class QueryingServerHelperTest {
 
 	@Test
 	public void fhirQueryTest() {
-		doReturn(fhirResponse).when(queryingServerHelper).queryServer(any(), anyBoolean());
+		doReturn(fhirResponse).when(queryingServerHelper).queryServer(any(), any());
 		FhirResponse<List<IBaseResource>> iResourceList = queryingServerHelper.queryResourcesResponse("Patient", null, null, IDENTIFIER);
 		Assert.assertNotNull(iResourceList);
 	}
@@ -170,14 +173,14 @@ public class QueryingServerHelperTest {
 	public void queryPartTest() {
 		List<IBaseResource> NullIBaseResource = new ArrayList<IBaseResource>();
 		FhirResponse<List<IBaseResource>> fhirResponseNull = new FhirResponse<List<IBaseResource>>(NullIBaseResource, 200, "testing");
-		doReturn(fhirResponseNull).when(queryingServerHelper).queryServer(any(), anyBoolean());
+		doReturn(fhirResponseNull).when(queryingServerHelper).queryServer(any(), any());
 		FhirResponse<List<IBaseResource>> iResourceList = queryingServerHelper.queryResourcesResponse("Observation",patient.getId().getIdPart(), SUBJECT, null);
 		Assert.assertNotNull(iResourceList);
 	}
 
 	@Test
 	public void fhirQueryAndQueryPartTestWithNullFhirVersion() {
-		doReturn(fhirResponse).when(queryingServerHelper).queryServer(any(), anyBoolean());
+		doReturn(fhirResponse).when(queryingServerHelper).queryServer(any(), any());
 		doReturn(fhirResponseObservation).when(queryingServerHelper).getResourceByIdResponse(any(), any());
 		FhirResponse<List<IBaseResource>> iResourceList = queryingServerHelper.queryResourcesResponse("Observation",patient.getId().getIdPart(), SUBJECT, IDENTIFIER);
 		Assert.assertNotNull(iResourceList);

--- a/fhir-query-helper-dstu3/pom.xml
+++ b/fhir-query-helper-dstu3/pom.xml
@@ -26,7 +26,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-dstu3</artifactId>
-	<version>0.0.13</version>
+	<version>0.0.14</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper DSTU3</description>
 

--- a/fhir-query-helper-dstu3/src/main/java/io/elimu/a2d2/cds/fhir/helper/dstu3/QueryingServerHelper.java
+++ b/fhir-query-helper-dstu3/src/main/java/io/elimu/a2d2/cds/fhir/helper/dstu3/QueryingServerHelper.java
@@ -23,8 +23,10 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.rest.client.api.IRestfulClientFactory;
+import io.elimu.a2d2.cds.fhir.helper.FetchCallRetry;
 import io.elimu.a2d2.cds.fhir.helper.FhirClientWrapper;
 import io.elimu.a2d2.cds.fhir.helper.FhirResponse;
+import io.elimu.a2d2.cds.fhir.helper.QueryBuilder;
 import io.elimu.a2d2.cds.fhir.helper.QueryingCallback;
 import io.elimu.a2d2.cds.fhir.helper.QueryingServerHelperBase;
 
@@ -96,7 +98,7 @@ public class QueryingServerHelper extends QueryingServerHelperBase<QueryingServe
 	}
 	
 	@Override
-	public FhirResponse<List<IBaseResource>> queryServer(String resourceQuery, boolean paging) {
+	public FhirResponse<List<IBaseResource>> queryServer(String resourceQuery, QueryBuilder builder) {
 		FhirClientWrapper client = clients.next();
 		FhirResponse<List<IBaseResource>> resourceBundle = null;
 		log.debug("Fetching {} resources using client for version {} ", client.getFhirContext().getVersion().getVersion().name(),
@@ -105,13 +107,13 @@ public class QueryingServerHelper extends QueryingServerHelperBase<QueryingServe
 			@Override
 			public List<IBaseResource> execute(FhirClientWrapper client) {
 				log.debug("Invoking url {}", resourceQuery);
-				Bundle bundle = client.fetchResourceFromUrl(Bundle.class, resourceQuery);
+				Bundle bundle = new FetchCallRetry<Bundle>(builder, b -> client.fetchResourceFromUrl(Bundle.class, resourceQuery)).retryRestCall(client);
 				List<IBaseResource> retval = new LinkedList<>();
 				bundle.getEntry().forEach(e -> retval.add((IBaseResource) e.getResource()));
-				while (paging && bundle.getLink("next") != null) {
+				while (builder.hasPaging() && bundle.getLink("next") != null) {
 					final String url = bundle.getLink("next").getUrl();
 					log.debug("Invoking url {}", url);
-					bundle = client.fetchResourceFromUrl(Bundle.class, url);
+					bundle = new FetchCallRetry<Bundle>(builder, b -> client.fetchResourceFromUrl(Bundle.class, url)).retryRestCall(client);
 					bundle.getEntry().forEach(e -> retval.add((IBaseResource) e.getResource()));
 				}
 				return retval;

--- a/fhir-query-helper-dstu3/src/test/java/io/elimu/a2d2/cds/fhir/helper/test/QueryingServerHelperCacheTest.java
+++ b/fhir-query-helper-dstu3/src/test/java/io/elimu/a2d2/cds/fhir/helper/test/QueryingServerHelperCacheTest.java
@@ -16,6 +16,7 @@ package io.elimu.a2d2.cds.fhir.helper.test;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.mockito.ArgumentMatchers.eq;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -29,6 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 import io.elimu.a2d2.cds.fhir.cache.CacheUtil;
 import io.elimu.a2d2.cds.fhir.helper.FhirResponse;
+import io.elimu.a2d2.cds.fhir.helper.QueryBuilder;
 import io.elimu.a2d2.cds.fhir.helper.dstu3.QueryingServerHelper;
 
 @SuppressWarnings("static-access")
@@ -91,13 +93,13 @@ public class QueryingServerHelperCacheTest {
 
 
 		doReturn(resourceQuery_1).when(queryingServerHelper).getResourceQuery(resourceType_1, subjectId_1, subjectRefAttribute_1, fhirQuery_1);
-		doReturn(retval_1).when(queryingServerHelper).queryServer(resourceQuery_1, true);
+		doReturn(retval_1).when(queryingServerHelper).queryServer(eq(resourceQuery_1), eq(new QueryBuilder().paging(true)));
 
 		doReturn(resourceQuery_2).when(queryingServerHelper).getResourceQuery(resourceType_2, subjectId_2, subjectRefAttribute_2, fhirQuery_2);
-		doReturn(retval_2).when(queryingServerHelper).queryServer(resourceQuery_2, true);
+		doReturn(retval_2).when(queryingServerHelper).queryServer(eq(resourceQuery_2), eq(new QueryBuilder().paging(true)));
 
 		doReturn(resourceQuery_3).when(queryingServerHelper).getResourceQuery(resourceType_3, subjectId_3, subjectRefAttribute_3, fhirQuery_3);
-		doReturn(retval_3).when(queryingServerHelper).queryServer(resourceQuery_3, true);
+		doReturn(retval_3).when(queryingServerHelper).queryServer(eq(resourceQuery_3), eq(new QueryBuilder().paging(true)));
 	}
 
 	@Test

--- a/fhir-query-helper-r4/pom.xml
+++ b/fhir-query-helper-r4/pom.xml
@@ -26,7 +26,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-r4</artifactId>
-	<version>0.0.13</version>
+	<version>0.0.14</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper R4</description>
 

--- a/fhir-query-helper-r4/src/main/java/io/elimu/a2d2/cds/fhir/helper/r4/QueryingServerHelper.java
+++ b/fhir-query-helper-r4/src/main/java/io/elimu/a2d2/cds/fhir/helper/r4/QueryingServerHelper.java
@@ -23,8 +23,10 @@ import org.hl7.fhir.r4.model.Bundle;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.rest.client.api.IRestfulClientFactory;
+import io.elimu.a2d2.cds.fhir.helper.FetchCallRetry;
 import io.elimu.a2d2.cds.fhir.helper.FhirClientWrapper;
 import io.elimu.a2d2.cds.fhir.helper.FhirResponse;
+import io.elimu.a2d2.cds.fhir.helper.QueryBuilder;
 import io.elimu.a2d2.cds.fhir.helper.QueryingCallback;
 import io.elimu.a2d2.cds.fhir.helper.QueryingServerHelperBase;
 
@@ -96,7 +98,7 @@ public class QueryingServerHelper extends QueryingServerHelperBase<QueryingServe
 	}
 	
 	@Override
-	public FhirResponse<List<IBaseResource>> queryServer(String resourceQuery, boolean paging) {
+	public FhirResponse<List<IBaseResource>> queryServer(String resourceQuery, QueryBuilder builder) {
 		FhirClientWrapper client = clients.next();
 		FhirResponse<List<IBaseResource>> resourceBundle = null;
 		log.debug("Fetching {} resources using client for version {} ", client.getFhirContext().getVersion().getVersion().name(),
@@ -105,13 +107,13 @@ public class QueryingServerHelper extends QueryingServerHelperBase<QueryingServe
 			@Override
 			public List<IBaseResource> execute(FhirClientWrapper client) {
 				log.debug("Invoking url {}", resourceQuery);
-				Bundle bundle = client.fetchResourceFromUrl(Bundle.class, resourceQuery);
+				Bundle bundle = new FetchCallRetry<Bundle>(builder, b -> client.fetchResourceFromUrl(Bundle.class, resourceQuery)).retryRestCall(client);
 				List<IBaseResource> retval = new LinkedList<>();
 				bundle.getEntry().forEach(e -> retval.add((IBaseResource) e.getResource()));
-				while (paging && bundle.getLink("next") != null) {
+				while (builder.hasPaging() && bundle.getLink("next") != null) {
 					final String url = bundle.getLink("next").getUrl();
 					log.debug("Invoking url {}", url);
-					bundle = client.fetchResourceFromUrl(Bundle.class, url);
+					bundle = new FetchCallRetry<Bundle>(builder, b -> client.fetchResourceFromUrl(Bundle.class, url)).retryRestCall(client);
 					bundle.getEntry().forEach(e -> retval.add((IBaseResource) e.getResource()));
 				}
 				return retval;

--- a/fhir-query-helper-r4/src/test/java/io/elimu/a2d2/cds/fhir/helper/test/FhirTest.java
+++ b/fhir-query-helper-r4/src/test/java/io/elimu/a2d2/cds/fhir/helper/test/FhirTest.java
@@ -2,6 +2,7 @@ package io.elimu.a2d2.cds.fhir.helper.test;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.mockito.ArgumentMatchers.eq;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -39,7 +40,6 @@ public class FhirTest {
 	private static final String responseStatusInfo_2 = "responseStatusInfo - response first user_2";
 	FhirResponse<List<IBaseResource>> retval_2 = null;
 
-
 	@Before
 	public void setup() {
 		List<IBaseResource> iBaseList = new ArrayList<IBaseResource>();
@@ -55,8 +55,12 @@ public class FhirTest {
 		retval_1 = new FhirResponse<>(iBaseList, 200, responseStatusInfo_1);
 		retval_2 = new FhirResponse<>(iBaseList, 200, responseStatusInfo_2);
 
-		doReturn(retval_1).when(queryingServerHelper).queryServer(resourceQuery_1, false);
-		doReturn(retval_2).when(queryingServerHelper).queryServer(resourceQuery_2, true);
+		doReturn(retval_1).when(queryingServerHelper).queryServer(eq(resourceQuery_1), eq(new QueryBuilder().
+				resourceType("MedicationAdministration").
+				count(1).withParam("_sort", "-_lastUpdated").paging(false)));
+		doReturn(retval_2).when(queryingServerHelper).queryServer(resourceQuery_2, new QueryBuilder().paging(true));
+		doReturn(retval_2).when(queryingServerHelper).queryServer(eq(resourceQuery_2), eq(new QueryBuilder().
+				resourceType("Observation").count(2).withParam("_sort", "-date")));
 	}
 	
 	@Test

--- a/fhir-query-helper-r4/src/test/java/io/elimu/a2d2/cds/fhir/helper/test/QueryingServerHelperCacheTest.java
+++ b/fhir-query-helper-r4/src/test/java/io/elimu/a2d2/cds/fhir/helper/test/QueryingServerHelperCacheTest.java
@@ -14,6 +14,7 @@
 
 package io.elimu.a2d2.cds.fhir.helper.test;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
@@ -21,15 +22,18 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.InstantType;
 import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.StructureDefinition;
-import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
 import io.elimu.a2d2.cds.fhir.cache.CacheUtil;
 import io.elimu.a2d2.cds.fhir.helper.FhirResponse;
+import io.elimu.a2d2.cds.fhir.helper.QueryBuilder;
 import io.elimu.a2d2.cds.fhir.helper.r4.QueryingServerHelper;
 
 @SuppressWarnings("static-access")
@@ -92,13 +96,13 @@ public class QueryingServerHelperCacheTest {
 
 
 		doReturn(resourceQuery_1).when(queryingServerHelper).getResourceQuery(resourceType_1, subjectId_1, subjectRefAttribute_1, fhirQuery_1);
-		doReturn(retval_1).when(queryingServerHelper).queryServer(resourceQuery_1, true);
+		doReturn(retval_1).when(queryingServerHelper).queryServer(eq(resourceQuery_1), eq(new QueryBuilder().paging(true)));
 
 		doReturn(resourceQuery_2).when(queryingServerHelper).getResourceQuery(resourceType_2, subjectId_2, subjectRefAttribute_2, fhirQuery_2);
-		doReturn(retval_2).when(queryingServerHelper).queryServer(resourceQuery_2, true);
+		doReturn(retval_2).when(queryingServerHelper).queryServer(eq(resourceQuery_2), eq(new QueryBuilder().paging(true)));
 
 		doReturn(resourceQuery_3).when(queryingServerHelper).getResourceQuery(resourceType_3, subjectId_3, subjectRefAttribute_3, fhirQuery_3);
-		doReturn(retval_3).when(queryingServerHelper).queryServer(resourceQuery_3, true);
+		doReturn(retval_3).when(queryingServerHelper).queryServer(eq(resourceQuery_3), eq(new QueryBuilder().paging(true)));
 	}
 
 	@Test

--- a/generic-helpers/pom.xml
+++ b/generic-helpers/pom.xml
@@ -23,7 +23,7 @@
 		<version>0.0.9-SNAPSHOT</version>
 	</parent>
 	<artifactId>generic-helpers</artifactId>
-	<version>0.0.13</version>
+	<version>0.0.14</version>
 	<name>Base helpers for the Generic services</name>
 	<description>Contains WIHInvoker</description>
 

--- a/oauth-helpers/pom.xml
+++ b/oauth-helpers/pom.xml
@@ -27,7 +27,7 @@
 	</parent>
 
 	<artifactId>oauth-helpers</artifactId>
-	<version>0.0.13</version>
+	<version>0.0.14</version>
 	<description>OAuth Helper</description>
 
 	<properties>

--- a/oauth-helpers/src/test/java/io/elimu/a2d2/OAuthHelperTest.java
+++ b/oauth-helpers/src/test/java/io/elimu/a2d2/OAuthHelperTest.java
@@ -36,6 +36,7 @@ import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.rest.client.api.IClientInterceptor;
 import ca.uhn.fhir.rest.client.interceptor.BearerTokenAuthInterceptor;
 import io.elimu.a2d2.cds.fhir.helper.FhirResponse;
+import io.elimu.a2d2.cds.fhir.helper.QueryBuilder;
 import io.elimu.a2d2.cds.fhir.helper.QueryingServerHelperBase;
 import io.elimu.a2d2.cds.fhir.helper.QueryingServerHelperBase.FhirVersionAbs;
 import io.elimu.a2d2.genericmodel.NamedDataObject;
@@ -127,7 +128,7 @@ public class OAuthHelperTest {
 		}
 		
 		@Override
-		public FhirResponse<List<IBaseResource>> queryServer(String resourceQuery, boolean paging) {
+		public FhirResponse<List<IBaseResource>> queryServer(String resourceQuery, QueryBuilder builder) {
 			return new FhirResponse<List<IBaseResource>>(new ArrayList<IBaseResource>(), 200, "OK");
 		}
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<protobuf-java.version>3.21.8</protobuf-java.version>
 		<mockito.version>2.23.0</mockito.version>
 		<jedis.version>4.0.1</jedis.version>
-		<cds.helper.version>0.0.13</cds.helper.version>
+		<cds.helper.version>0.0.14</cds.helper.version>
 		<freemarker.version>2.3.30</freemarker.version>
 		<jacoco.version>0.8.7</jacoco.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>


### PR DESCRIPTION
Retry mechanishms added to CallREST work item handler and QueryingServerHelper REST invocations. Defaults to 3 retries, but can be configured through JVM properties, work item handler inputs, or QueryBuilder new methods, to have different retries and delays