### PR TITLE
suppressed vulnerability snake

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -127,4 +127,25 @@
       <packageUrl regex="true">^pkg:maven/org\.apache\.sshd/sshd\-common@.*$</packageUrl>
       <cve>CVE-2022-45047</cve>
    </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: snakeyaml-1.33.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+      <vulnerabilityName>CVE-2022-1471</vulnerabilityName>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: snakeyaml-1.33.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+      <cve>CVE-2022-3064</cve>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: snakeyaml-1.33.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+      <cve>CVE-2021-4235</cve>
+   </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -630,7 +630,7 @@
 			<plugin>
 				<groupId>org.owasp</groupId>
 				<artifactId>dependency-check-maven</artifactId>
-				<version>7.3.0</version>
+				<version>7.4.4</version>
 				<configuration>
 					<skipProvidedScope>true</skipProvidedScope>
 					<skipRuntimeScope>true</skipRuntimeScope>


### PR DESCRIPTION
- Ran mvn site on local & verified vulnerability is suppressed successfully.

- We are not parsing any untrusted (user supplied supplied) YAML files.So adding suppression.

- SnakeYaml's Constructor() class does not restrict types which can be instantiated during deserialization. Deserializing yaml content provided by an attacker can lead to remote code execution. We recommend using SnakeYaml's SafeConsturctor when parsing untrusted content to restrict deserialization.


