### PR TITLE
Mitigate dependency vulnerability in a2d2:woodstox-core-5.1.0.jar

### DIFF
--- a/core-wih/pom.xml
+++ b/core-wih/pom.xml
@@ -82,6 +82,12 @@
 			<groupId>com.sun.xml.ws</groupId>
 			<artifactId>jaxws-rt</artifactId>
 			<version>2.3.3</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.fasterxml.woodstox</groupId>
+					<artifactId>woodstox-core</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
     			<groupId>org.mvel</groupId>
@@ -123,6 +129,11 @@
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 			<version>${gson.version}</version>
+		</dependency>
+		<dependency>
+    		<groupId>com.fasterxml.woodstox</groupId>
+    		<artifactId>woodstox-core</artifactId>
+    		<version>6.4.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>

--- a/core-wih/pom.xml
+++ b/core-wih/pom.xml
@@ -87,6 +87,10 @@
 					<groupId>com.fasterxml.woodstox</groupId>
 					<artifactId>woodstox-core</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.codehaus.woodstox</groupId>
+					<artifactId>stax2-api</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
@@ -134,6 +138,17 @@
     		<groupId>com.fasterxml.woodstox</groupId>
     		<artifactId>woodstox-core</artifactId>
     		<version>6.4.0</version>
+    		<exclusions>
+    			<exclusion>
+    				<groupId>org.codehaus.woodstox</groupId>
+    				<artifactId>stax2-api</artifactId>
+    			</exclusion>
+    		</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.woodstox</groupId>
+			<artifactId>stax2-api</artifactId>
+			<version>4.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.elimu.a2d2</groupId>


### PR DESCRIPTION
Ran omnibus on local & verified SOFA & omnibus integration test cases passing
![image_2023_01_11T10_58_29_185Z](https://user-images.githubusercontent.com/94971091/211790203-d616c61e-04cc-4221-b067-557c0ad3d001.png)
![image_2023_01_11T10_57_17_016Z](https://user-images.githubusercontent.com/94971091/211790208-d111c9b1-5cb1-41b0-82ef-7d4912c75333.png)
![image_2023_01_11T10_58_00_328Z](https://user-images.githubusercontent.com/94971091/211790210-7a47411b-8839-407e-8883-e0809f214761.png)
