### PR TITLE
updated GetClient method to return client from jwt token 

### DIFF
--- a/kie-based-services/src/main/java/io/elimu/genericapi/service/GenericKieBasedService.java
+++ b/kie-based-services/src/main/java/io/elimu/genericapi/service/GenericKieBasedService.java
@@ -187,7 +187,7 @@ public class GenericKieBasedService extends AbstractKieService implements Generi
 	}
 	
 	private String getClient(ServiceRequest request) {
-		String auth = request.getHeader("Authorization");
+		String auth = request.getHeader("authorization");
 		if (auth == null) {
 			if ("*".equals(getDefaultCustomer())) {
 				return "default";


### PR DESCRIPTION
when the buildRequest method is called to build a ServiceRequest object from HttpServletRequest, it always stores header name as lower case. so updated the `getClient` method to get header from key authorization 

#### How this tested:
- Tested locally by passing auth header containing tenant.