### PR TITLE
mitigated vulnerability hl7-fhir-r5

### DIFF
--- a/cql-wih/pom.xml
+++ b/cql-wih/pom.xml
@@ -64,6 +64,10 @@
 					<groupId>org.antlr</groupId>
 					<artifactId>antlr4-runtime</artifactId>
 				</exclusion>
+        			<exclusion>
+        				<groupId>ca.uhn.hapi.fhir</groupId>
+        				<artifactId>org.hl7.fhir.r5</artifactId>
+        			</exclusion>
 			</exclusions>
 			<scope>test</scope>
 		</dependency>

--- a/fhir-helpers/pom.xml
+++ b/fhir-helpers/pom.xml
@@ -94,6 +94,12 @@
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-converter</artifactId>
 			<version>${hapi.fhir.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>ca.uhn.hapi.fhir</groupId>
+					<artifactId>org.hl7.fhir.r5</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>


### PR DESCRIPTION
Mitigated hl7-fhir-r5 vulnerability

- Tested by running omnibus on local
- Also ran script of omnibus-integration-test-stage