### PR TITLE
configApiClient variable population from generic service

### DIFF
--- a/kie-based-services/src/main/java/io/elimu/genericapi/service/GenericKieBasedService.java
+++ b/kie-based-services/src/main/java/io/elimu/genericapi/service/GenericKieBasedService.java
@@ -150,7 +150,9 @@ public class GenericKieBasedService extends AbstractKieService implements Generi
 				params.put("serviceRequest", request);
 				params.put("serviceResponse", defaultResponse());
 				params.put("defaultCustomer", getDefaultCustomer());
-				params.putAll(new ConfigAPIProcessVariableInitHelper().initVariables(request, getClient(request), getDependency(), getConfig()));
+                                String providedClient = getClient(request);
+                                params.put("configApiClient", providedClient);
+                                params.putAll(new ConfigAPIProcessVariableInitHelper().initVariables(request, providedClient, getDependency(), getConfig()));
 				WorkflowProcessInstance instance = (WorkflowProcessInstance) ksession.startProcess(procId, params);
 				ServiceResponse response = (ServiceResponse) instance.getVariable("serviceResponse");
 				if (response == null) {


### PR DESCRIPTION
In order to use the configApi provided client in the OAuth token, we need to pass it as a process variable. This PR takes care of that 