### PR TITLE
Updated dependency-check-maven version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -630,7 +630,7 @@
 			<plugin>
 				<groupId>org.owasp</groupId>
 				<artifactId>dependency-check-maven</artifactId>
-				<version>7.4.4</version>
+				<version>8.1.1</version>
 				<configuration>
 					<skipProvidedScope>true</skipProvidedScope>
 					<skipRuntimeScope>true</skipRuntimeScope>


### PR DESCRIPTION
- There is a bug in the dependency-check-maven dependency that we use to generate vulnerability reports that is causing a lot of new, and HIGH severity, vulnerabilities to appear in our reports that are false positives.