### PR TITLE
revert suppression plexus utils

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -190,11 +190,4 @@
       <packageUrl regex="true">^pkg:maven/org\.jboss\.resteasy/resteasy\-core@.*$</packageUrl>
       <vulnerabilityName>CVE-2023-0482</vulnerabilityName>
    </suppress>
-   <suppress>
-      <notes><![CDATA[
-      file name: plexus-utils-3.5.0.jar
-      ]]></notes>
-      <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-utils@.*$</packageUrl>
-      <cve>CVE-2021-4277</cve>
-</suppress>
 </suppressions>


### PR DESCRIPTION
- plexus-utils-3.5.1.jar vulnerability appearing in the report is due to a bug in the dependency-check-maven version used in a2d2