### PR TITLE
Mitigate dependency cxf-rt-bindings-soap-3.4.10.jar

### DIFF
--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -10,7 +10,7 @@
 	<description>Kie Based Services</description>
 
 	<properties>
-		<cxf.version>3.4.10</cxf.version>
+		<cxf.version>3.5.5</cxf.version>
 		<mixpanel.version>1.4.4</mixpanel.version>
 		<org.json.version>20220924</org.json.version>
 		<ant.version>1.10.11</ant.version>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -197,4 +197,11 @@
       <packageUrl regex="true">^pkg:maven/org\.json/json@.*$</packageUrl>
       <cve>CVE-2022-45688</cve>
    </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: cxf-rt-bindings-soap-3.5.5.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.apache\.cxf/cxf\-rt\-bindings\-soap@.*$</packageUrl>
+      <cve>CVE-2022-40705</cve>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
Mitigated cxf-rt-bindings-soap-3.4.10.jar vulnerability

- Tested by running omnibus on local
- Also ran script of omnibus-integration-test-stage

Adding suppression for this vulnerability because we are not using RPCRouterServlet of Apache SOAP in  a2d2, https://nvd.nist.gov/vuln/detail/CVE-2022-40705