### PR TITLE
Changes needed for dynamically determining auth properties

### DIFF
--- a/fhir-query-helper-dstu2/src/test/java/io/elimu/a2d2/cds/fhir/helper/test/QueryingServerHelperTest.java
+++ b/fhir-query-helper-dstu2/src/test/java/io/elimu/a2d2/cds/fhir/helper/test/QueryingServerHelperTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import ca.uhn.fhir.context.FhirContext;
@@ -40,6 +41,7 @@ import io.elimu.a2d2.cds.fhir.helper.FhirResponse;
 import io.elimu.a2d2.cds.fhir.helper.QueryBuilder;
 import io.elimu.a2d2.cds.fhir.helper.QueryingServerHelper;
 
+@Ignore("No valid public FHIR servers available to test this")
 public class QueryingServerHelperTest {
 
 	private static QueryingServerHelper queryingServerHelper = spy(QueryingServerHelper.class);

--- a/fhir-resource-wih/src/test/java/io/elimu/a2d2/fhir_resource_wih/ResourceReadDelegateTest.java
+++ b/fhir-resource-wih/src/test/java/io/elimu/a2d2/fhir_resource_wih/ResourceReadDelegateTest.java
@@ -30,7 +30,7 @@ import ca.uhn.fhir.model.dstu2.valueset.AdministrativeGenderEnum;
 import io.elimu.a2d2.exception.FhirServerException;
 import io.elimu.a2d2.fhirresourcewih.ResourceReadDelegate;
 
-//@Ignore ("disable for now as the test is based on public testing server")
+@Ignore ("disable for now as the test is based on public testing server")
 public class ResourceReadDelegateTest {
 
 	private static final String fhirUrl = "http://hapi.fhir.org/baseDstu2";

--- a/kie-based-services/src/main/java/io/elimu/genericapi/service/GenericService.java
+++ b/kie-based-services/src/main/java/io/elimu/genericapi/service/GenericService.java
@@ -1,6 +1,7 @@
 package io.elimu.genericapi.service;
 
 import java.util.List;
+import java.util.Properties;
 
 import org.kie.api.task.model.Task;
 
@@ -17,4 +18,5 @@ public interface GenericService {
 	void updateTask(Task task) throws GenericServiceException;
 	Task getTask(Long taskId);
 	List<String> getOtherCustomers();
+	Properties getConfig();
 }

--- a/kie-based-services/src/main/java/io/elimu/genericapi/service/GenericTempService.java
+++ b/kie-based-services/src/main/java/io/elimu/genericapi/service/GenericTempService.java
@@ -2,19 +2,27 @@ package io.elimu.genericapi.service;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 
 import org.kie.api.task.model.Task;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.elimu.a2d2.cdsmodel.Dependency;
 import io.elimu.a2d2.genericmodel.ServiceRequest;
 import io.elimu.a2d2.genericmodel.ServiceResponse;
+import io.elimu.a2d2.process.ServiceUtils;
+import io.elimu.serviceapi.service.AppContextUtils;
 
 public class GenericTempService implements GenericService {
 
+	private static final Logger LOG = LoggerFactory.getLogger(GenericTempService.class);
+	
 	private String id;
 	private String defaultCustomer;
 	private Dependency dependency;
-
+	private Properties config;
+	
 	public GenericTempService(String releaseId, String defaultCustomer) {
 		this.defaultCustomer = defaultCustomer;
 		if (releaseId == null || releaseId.split(":").length < 3) {
@@ -23,6 +31,18 @@ public class GenericTempService implements GenericService {
 		String[] parts = releaseId.split(":");
 		this.id = parts[1];
 		this.dependency = new Dependency(parts[0], parts[1], parts[2]);
+	}
+
+	@Override
+	public Properties getConfig() {
+		if (this.config == null) {
+			try {
+				this.config = ServiceUtils.getConfig(getDependency(), AppContextUtils.getInstance().getProfileName());
+			} catch (Exception e) {
+				LOG.warn("COULD NOT INITIALIZE CONFIG ON DEMAND", e);
+			}
+		}
+		return config;
 	}
 
 	@Override

--- a/kie-based-services/src/main/java/io/elimu/serviceapi/config/JWTAuthUtil.java
+++ b/kie-based-services/src/main/java/io/elimu/serviceapi/config/JWTAuthUtil.java
@@ -46,6 +46,9 @@ public class JWTAuthUtil {
 	
 	public static boolean isValidJwt(String jwtToken, String serviceId) {
 		try {
+			if (jwtToken == null || "NO_CREDS".equalsIgnoreCase(jwtToken)) {
+				return false;
+			}
 			LOGGER.debug("Parsing token " + jwtToken);
 			DecodedJWT jwt = JWT.decode(jwtToken.replace("Bearer", "").trim());
 			GenericKieBasedService service = serviceId == null ? null : (GenericKieBasedService) RunningServices.getInstance().get(serviceId);
@@ -62,10 +65,6 @@ public class JWTAuthUtil {
 			if (aud == null || validAud.isEmpty() || !aud.stream().anyMatch(a -> validAud.contains(a))) {
 				return false;
 			}
-			//Ensure that the exp value is not before the current date/time.
-//			if (jwt.getExpiresAt().before(new Date())) {
-//				return false;
-//			}
 			//Ensure the jku value, if present, matches the request and validates the signature
 			String jku = jwt.getHeaderClaim("jku") == null ? null : jwt.getHeaderClaim("jku").asString();
 			List<String> validJku = getConfigPropertyAsString(serviceProperties, "jwtValidJku");

--- a/service-daos/src/main/java/io/elimu/service/models/ServiceInfo.java
+++ b/service-daos/src/main/java/io/elimu/service/models/ServiceInfo.java
@@ -23,6 +23,7 @@ import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.Table;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -56,7 +57,7 @@ public class ServiceInfo {
     @Column(nullable = false)
     private String status;
 
-    @ElementCollection
+    @ElementCollection( fetch = FetchType.EAGER )
     @CollectionTable(name="othercustomers", joinColumns= {@JoinColumn(name="ServiceId"), @JoinColumn(name="ServiceVersion")})
     @Column(name="element")
     private Set<String> otherCustomers = new HashSet<String>();


### PR DESCRIPTION
These changes allow us to determine as early as possible the customers, packages and service types of deployed services. Needed for Omnibus to determine which paths are open to the public.