### PR TITLE
Mitigate dependency vulnerability org.hl7.fhir.r5-5.5.7.jar

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -211,4 +211,18 @@
       <packageUrl regex="true">^pkg:maven/ca\.uhn\.hapi\.fhir/org\.hl7\.fhir\.utilities@.*$</packageUrl>
       <vulnerabilityName>CVE-2023-28465</vulnerabilityName>
    </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: org.hl7.fhir.r5-5.5.7.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/ca\.uhn\.hapi\.fhir/org\.hl7\.fhir\.r5@.*$</packageUrl>
+      <vulnerabilityName>CVE-2023-24057</vulnerabilityName>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: org.hl7.fhir.convertors-5.5.7.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/ca\.uhn\.hapi\.fhir/org\.hl7\.fhir\.convertors@.*$</packageUrl>
+      <vulnerabilityName>CVE-2023-24057</vulnerabilityName>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
Mitigated vulnerability org.hl7.fhir.r5-5.5.7.jar by adding suppression
- Ran mvn site on local & verified vulnerability is suppressed successfully.