### PR TITLE
CachingHttpClient re-enabling by putting it after the rest of the timeout configurations

### DIFF
--- a/cql-wih/src/main/java/io/elimu/a2d2/cql/PlanDefCdsInlineWorkItemHandler.java
+++ b/cql-wih/src/main/java/io/elimu/a2d2/cql/PlanDefCdsInlineWorkItemHandler.java
@@ -71,12 +71,12 @@ public class PlanDefCdsInlineWorkItemHandler implements WorkItemHandler {
 			
 			Object restClientFactory = ctxClass.getMethod("getRestfulClientFactory").invoke(this.ctx);
 			Class<?> rcfClass = cl.loadClass("ca.uhn.fhir.rest.client.api.IRestfulClientFactory");
-			rcfClass.getMethod("setHttpClient", Object.class).invoke(restClientFactory, new CachingHttpClient());
 			rcfClass.getMethod("setConnectTimeout", int.class).invoke(restClientFactory, 30000);
 			rcfClass.getMethod("setSocketTimeout", int.class).invoke(restClientFactory, 30000);
 			Class<?> svmeClass = cl.loadClass("ca.uhn.fhir.rest.client.api.ServerValidationModeEnum");
 			Object never = svmeClass.getField("NEVER").get(null);
 			rcfClass.getMethod("setServerValidationMode", svmeClass).invoke(restClientFactory, never);
+			rcfClass.getMethod("setHttpClient", Object.class).invoke(restClientFactory, new CachingHttpClient());
 			
 			Object ctxVersion = ctxClass.getMethod("getVersion").invoke(ctx);
 			Object ctxVersionVersion = ctxVersion.getClass().getMethod("getVersion").invoke(ctxVersion);


### PR DESCRIPTION
Moving the setHttpClient method a few lines after the setConnectTimeout and setSocketTimeout calls prevents HttpClient from being reset on the underlying implementation