### PR TITLE
Mitigate dependency vulnerability commons-beanutils-1.9.3.jar

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -225,4 +225,18 @@
       <packageUrl regex="true">^pkg:maven/ca\.uhn\.hapi\.fhir/org\.hl7\.fhir\.convertors@.*$</packageUrl>
       <vulnerabilityName>CVE-2023-24057</vulnerabilityName>
    </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: commons-beanutils-1.9.3.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/commons\-beanutils/commons\-beanutils@.*$</packageUrl>
+      <vulnerabilityName>CVE-2014-0114</vulnerabilityName>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: commons-beanutils-1.9.3.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/commons\-beanutils/commons\-beanutils@.*$</packageUrl>
+      <cve>CVE-2019-10086</cve>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
Mitigated vulnerability commons-beanutils-1.9.3.jar by adding suppression

- Ran mvn site on local & verified vulnerability is suppressed successfully.