### PR TITLE
JedisHelper updates required for dependency structure

### DIFF
--- a/generic-helpers/pom.xml
+++ b/generic-helpers/pom.xml
@@ -23,7 +23,7 @@
 		<version>0.0.9-SNAPSHOT</version>
 	</parent>
 	<artifactId>generic-helpers</artifactId>
-	<version>0.0.15</version>
+	<version>0.0.16</version>
 	<name>Base helpers for the Generic services</name>
 	<description>Contains WIHInvoker</description>
 

--- a/generic-helpers/src/main/java/io/elimu/a2d2/helpers/JedisHelper.java
+++ b/generic-helpers/src/main/java/io/elimu/a2d2/helpers/JedisHelper.java
@@ -64,7 +64,8 @@ public class JedisHelper {
 	}
 
 	public void register(String key, int timeoutInSeconds) {
-		jedis.setex(key, timeoutInSeconds, "x");
+		jedis.set(key, "x");
+		jedis.expire(key, timeoutInSeconds);
 	}
 
 }

--- a/generic-helpers/src/main/java/io/elimu/a2d2/helpers/JedisHelper.java
+++ b/generic-helpers/src/main/java/io/elimu/a2d2/helpers/JedisHelper.java
@@ -60,11 +60,11 @@ public class JedisHelper {
 	}
 
 	public boolean containsKey(String key) {
-		return jedis.exists(key.getBytes());
+		return jedis.exists(key);
 	}
 
 	public void register(String key, int timeoutInSeconds) {
-		jedis.setex(key.getBytes(), timeoutInSeconds, new byte[] {1,2,3});
+		jedis.setex(key, timeoutInSeconds, "x");
 	}
 
 }

--- a/generic-helpers/src/test/java/io/elimu/a2d2/helpers/JedisHelperTest.java
+++ b/generic-helpers/src/test/java/io/elimu/a2d2/helpers/JedisHelperTest.java
@@ -1,6 +1,7 @@
 package io.elimu.a2d2.helpers;
 
 import java.io.IOException;
+import java.util.Random;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -15,9 +16,20 @@ public class JedisHelperTest {
 	
 	@BeforeClass
 	public static void startup() throws IOException {
-		int port = Integer.valueOf(System.getProperty("cache.jedis.port", "6379"));
-		redis = RedisServer.newRedisServer(port);
-		redis.start();
+		int port = new Random().nextInt(5000) + 3000;
+		boolean loaded = false;
+		int attempts = 0;
+		while (!loaded && attempts < 10) {
+			try {
+				System.err.println("Attempting redis server mock at port " + port + "...");
+				redis = RedisServer.newRedisServer(port);
+				redis.start();
+				loaded = true;
+			} catch (Exception e) {
+				port = new Random().nextInt(5000) + 3000;
+				attempts++;
+			}
+		}
 		System.setProperty("cache.jedis.port", String.valueOf(redis.getBindPort()));//port might differ from initial configuration
 	}
 	

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
 				<groupId>${project.groupId}</groupId>
 				<artifactId>generic-helpers</artifactId>
 				<!--version>${cds.helper.version}</version-->
-				<version>0.0.15</version>
+				<version>0.0.16</version>
 			</dependency>
 			<dependency>
 				<groupId>${project.groupId}</groupId>


### PR DESCRIPTION
These changes are needed because of dependency problems, where some versions of the services code might use older versions of redis, needing the old API to be used (with strings instead of byte arrays)