### PR TITLE
Gt 1361 correlation id preserving

### DIFF
--- a/core-wih/src/main/java/io/elimu/a2d2/corewih/ServiceRestAPIDelegate.java
+++ b/core-wih/src/main/java/io/elimu/a2d2/corewih/ServiceRestAPIDelegate.java
@@ -29,6 +29,7 @@ import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -131,7 +132,9 @@ public class ServiceRestAPIDelegate implements WorkItemHandler {
 			else {
 				logger.warn("No authentication for the rest api request " + url);
 			}
-
+			if (!headers.containsKey("X-Correlation-ID")) {
+				headers.add("X-Correlation-ID", MDC.get("correlationId"));
+			}
 
 			HttpEntity<?> entity = new HttpEntity<>(body, headers);
 			logger.debug("Prepared http entity");

--- a/cql-wih/src/main/java/io/elimu/a2d2/cql/CachingHttpClient.java
+++ b/cql-wih/src/main/java/io/elimu/a2d2/cql/CachingHttpClient.java
@@ -27,8 +27,8 @@ public class CachingHttpClient implements HttpClient {
 	public CachingHttpClient() {
 		PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager(5000,
 				TimeUnit.MILLISECONDS);
-		connectionManager.setMaxTotal(20);
-		connectionManager.setDefaultMaxPerRoute(20);
+		connectionManager.setMaxTotal(200);
+		connectionManager.setDefaultMaxPerRoute(200);
 		connectionManager.setValidateAfterInactivity(300000);
 		RequestConfig defaultRequestConfig =
 			RequestConfig.custom()

--- a/fhir-helpers/pom.xml
+++ b/fhir-helpers/pom.xml
@@ -20,7 +20,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.elimu.a2d2</groupId>
 	<artifactId>fhir-helpers</artifactId>
-	<version>0.0.14</version>
+	<version>0.0.15</version>
 	<packaging>jar</packaging>
 	<name>fhir-helpers</name>
 	<url>http://maven.apache.org</url>

--- a/fhir-query-helper-base/pom.xml
+++ b/fhir-query-helper-base/pom.xml
@@ -27,7 +27,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-base</artifactId>
-	<version>0.0.14</version>
+	<version>0.0.15</version>
 	<description>CDS Helper base</description>
 
 	<properties>

--- a/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/helper/CorrelationIdInterceptor.java
+++ b/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/helper/CorrelationIdInterceptor.java
@@ -1,0 +1,16 @@
+package io.elimu.a2d2.cds.fhir.helper;
+
+import org.slf4j.MDC;
+
+import ca.uhn.fhir.rest.client.interceptor.SimpleRequestHeaderInterceptor;
+
+public class CorrelationIdInterceptor extends SimpleRequestHeaderInterceptor {
+
+	private static final String CORRELATION_ID_HEADER_NAME = "X-Correlation-ID";
+	private static final String CORRELATION_ID_LOG_VAR_NAME = "correlationId";
+
+	public CorrelationIdInterceptor() {
+		super(CORRELATION_ID_HEADER_NAME, MDC.get(CORRELATION_ID_LOG_VAR_NAME));
+	}
+
+}

--- a/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/helper/QueryingServerHelperBase.java
+++ b/fhir-query-helper-base/src/main/java/io/elimu/a2d2/cds/fhir/helper/QueryingServerHelperBase.java
@@ -301,8 +301,10 @@ public abstract class QueryingServerHelperBase<T, U extends IBaseResource> imple
 					client.registerInterceptor(i);
 				}
 				SingleAuthInterceptor singleAuth = new SingleAuthInterceptor();
+				CorrelationIdInterceptor correlationId = new CorrelationIdInterceptor();
 				client.registerInterceptor(singleAuth);
 				client.registerInterceptor(tracker);
+				client.registerInterceptor(correlationId);
 				try {
 					result = callback.execute(client);
 				} catch (RuntimeException t) {
@@ -312,8 +314,8 @@ public abstract class QueryingServerHelperBase<T, U extends IBaseResource> imple
 					log.debug("Unregistering interceptor " + i);
 					client.unregisterInterceptor(i);
 				}
+				client.unregisterInterceptor(correlationId);
 				client.unregisterInterceptor(singleAuth);
-				
 				client.unregisterInterceptor(tracker);
 			};
 		} finally {

--- a/fhir-query-helper-dstu2/pom.xml
+++ b/fhir-query-helper-dstu2/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-dstu2</artifactId>
-	<version>0.0.14</version>
+	<version>0.0.15</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper</description>
 

--- a/fhir-query-helper-dstu3/pom.xml
+++ b/fhir-query-helper-dstu3/pom.xml
@@ -26,7 +26,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-dstu3</artifactId>
-	<version>0.0.14</version>
+	<version>0.0.15</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper DSTU3</description>
 

--- a/fhir-query-helper-r4/pom.xml
+++ b/fhir-query-helper-r4/pom.xml
@@ -26,7 +26,7 @@
 	</parent>
 
 	<artifactId>fhir-query-helper-r4</artifactId>
-	<version>0.0.14</version>
+	<version>0.0.15</version>
 	<packaging>jar</packaging>
 	<description>CDS Helper R4</description>
 

--- a/oauth-helpers/pom.xml
+++ b/oauth-helpers/pom.xml
@@ -27,7 +27,7 @@
 	</parent>
 
 	<artifactId>oauth-helpers</artifactId>
-	<version>0.0.14</version>
+	<version>0.0.15</version>
 	<description>OAuth Helper</description>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<protobuf-java.version>3.21.8</protobuf-java.version>
 		<mockito.version>2.23.0</mockito.version>
 		<jedis.version>4.0.1</jedis.version>
-		<cds.helper.version>0.0.14</cds.helper.version>
+		<cds.helper.version>0.0.15</cds.helper.version>
 		<freemarker.version>2.3.30</freemarker.version>
 		<jacoco.version>0.8.7</jacoco.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>


### PR DESCRIPTION
So that other HTTP components called from services also use the same correlation id