### PR TITLE
Mitigate dependency vulnerability in a2d2: quartz-2.3.2.jar

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -246,4 +246,11 @@
       <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
       <cve>CVE-2023-35116</cve>
    </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: quartz-2.3.2.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.quartz\-scheduler/quartz@.*$</packageUrl>
+      <cve>CVE-2023-39017</cve>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
Added suppression to the quartz vulnerability.
We are not directly vulnerable to this vulnerability. It is related to the method org.quartz.jobs.ee.jms.SendQueueMessageJob.execute(JobExecutionContext).