### PR TITLE
Mitigate dependency vulnerability in a2d2: wildfly-elytron-2.0.0.Final.jar (shaded: org.apache.sshd:sshd-common:2.7.0)

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -11,9 +11,10 @@
       <notes><![CDATA[
       file name: spring-security-crypto-5.7.5.jar
       ]]></notes>
-      <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
+      <packageUrl regex="true">
+         ^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
       <vulnerabilityName>CVE-2020-5408</vulnerabilityName>
-   </suppress>   
+   </suppress>
    <suppress>
       <notes><![CDATA[
       file name: maven-core-3.3.9.jar
@@ -27,7 +28,7 @@
       file name: xstream-1.4.19.jar
       ]]></notes>
       <packageUrl regex="true">^pkg:maven/com\.thoughtworks\.xstream/xstream@.*$</packageUrl>
-     <cve>CVE-2022-40151</cve>
+      <cve>CVE-2022-40151</cve>
    </suppress>
    <suppress>
       <notes><![CDATA[
@@ -145,7 +146,8 @@
       <notes><![CDATA[
       file name: wildfly-elytron-password-impl-2.0.0.Final.jar
       ]]></notes>
-      <packageUrl regex="true">^pkg:maven/org\.wildfly\.security/wildfly\-elytron\-password\-impl@.*$</packageUrl>
+      <packageUrl regex="true">
+         ^pkg:maven/org\.wildfly\.security/wildfly\-elytron\-password\-impl@.*$</packageUrl>
       <vulnerabilityName>CVE-2022-3143</vulnerabilityName>
    </suppress>
    <suppress>
@@ -252,5 +254,12 @@
       ]]></notes>
       <packageUrl regex="true">^pkg:maven/org\.quartz\-scheduler/quartz@.*$</packageUrl>
       <cve>CVE-2023-39017</cve>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: wildfly-elytron-2.0.0.Final.jar (shaded: org.apache.sshd:sshd-common:2.7.0)
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.apache\.sshd/sshd\-common@.*$</packageUrl>
+      <vulnerabilityName>CVE-2023-35887</vulnerabilityName>
    </suppress>
 </suppressions>


### PR DESCRIPTION
- Class org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider in Apache MINA SSHD <= 2.9.1 uses Java deserialization to load a serialized java.security.PrivateKey. 

- The class is one of several implementations that an implementor using Apache MINA SSHD can choose for loading the host keys of an SSH server.

