### PR TITLE
Mitigate dependency vulnerability plexus-cipher-2.0.jar

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -262,4 +262,18 @@
       <packageUrl regex="true">^pkg:maven/org\.apache\.sshd/sshd\-common@.*$</packageUrl>
       <vulnerabilityName>CVE-2023-35887</vulnerabilityName>
    </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: plexus-cipher-2.0.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-cipher@.*$</packageUrl>
+      <cve>CVE-2022-4245</cve>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: plexus-cipher-2.0.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-cipher@.*$</packageUrl>
+      <cve>CVE-2022-4244</cve>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
Mitigated dependency vulnerability plexus-cipher-2.0.jar by adding suppression

- Ran mvn site on local & verified vulnerability is suppressed successfully.