### PR TITLE
Mitigate dependency vulnerability in a2d2: plexus-interpolation-1.26.jar

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -276,4 +276,18 @@
       <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-cipher@.*$</packageUrl>
       <cve>CVE-2022-4244</cve>
    </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: plexus-interpolation-1.26.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-interpolation@.*$</packageUrl>
+      <cve>CVE-2022-4244</cve>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: plexus-interpolation-1.26.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-interpolation@.*$</packageUrl>
+      <cve>CVE-2022-4245</cve>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
Suppressed the vulnerability for `plexus-interpolation-1.26.jar.`
We are not directly vulnerable to this vulnerability.
The issue is that `org.codehaus.plexus.util.xml.XmlWriterUtil`#writeComment fails to sanitize comments for a "-->" sequence. This issue means that text contained in the command string could be interpreted as XML and allow for XML injection.
A flaw was found in `codeplex-codehaus`, which we are not using anywhere.
A directory traversal attack (also known as path traversal) aims to access files and directories stored outside the intended folder to which we are immune.

https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Acodehaus-plexus_project&cpe_product=cpe%3A%2F%3Acodehaus-plexus_project%3Acodehaus-plexus&cpe_version=cpe%3A%2F%3Acodehaus-plexus_project%3Acodehaus-plexus%3A1.26