### PR TITLE
Mitigate dependency vulnerability plexus-component-annotations-2.1.0.jar

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -290,4 +290,18 @@
       <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-interpolation@.*$</packageUrl>
       <cve>CVE-2022-4245</cve>
    </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: plexus-component-annotations-2.1.0.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-component\-annotations@.*$</packageUrl>
+      <cve>CVE-2022-4244</cve>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: plexus-component-annotations-2.1.0.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-component\-annotations@.*$</packageUrl>
+      <cve>CVE-2022-4245</cve>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
Mitigated dependency vulnerability plexus-component-annotations-2.1.0.jar by adding suppression

- Ran mvn site on local & verified vulnerability is suppressed successfully.