### PR TITLE
Mitigate dependency vulnerability plexus-classworlds-2.6.0.jar

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -318,4 +318,18 @@
       <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-sec\-dispatcher@.*$</packageUrl>
       <cve>CVE-2022-4245</cve>
    </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: plexus-classworlds-2.6.0.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-classworlds@.*$</packageUrl>
+      <cve>CVE-2022-4244</cve>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: plexus-classworlds-2.6.0.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-classworlds@.*$</packageUrl>
+      <cve>CVE-2022-4245</cve>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
Mitigated dependency vulnerability plexus-classworlds-2.6.0.jar by adding suppression

- Ran mvn site on local & verified vulnerability is suppressed successfully.