### PR TITLE
Mitigate dependency vulnerability in a2d2: json-20230227.jar

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -332,4 +332,11 @@
       <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-classworlds@.*$</packageUrl>
       <cve>CVE-2022-4245</cve>
    </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: json-20230227.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.json/json@.*$</packageUrl>
+      <cve>CVE-2023-5072</cve>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
Suppressed the vulnerability for `json-20230227.jar`
This vulnerability appears due to the `JSONTokener.next()` which leads to the "Parsing untrusted input could then potentially lead to OutOfMemoryError even for quite small input strings."
We have not used the **JSONTokener.next()** in the code, so we are not directly vulnerable to this vulnerability.

https://nvd.nist.gov/vuln/detail/CVE-2023-5072

https://github.com/stleary/JSON-java/issues/758