### PR TITLE
Mitigate dependency vulnerability in a2d2: json-20230227.jar

### DIFF
--- a/core-wih/pom.xml
+++ b/core-wih/pom.xml
@@ -32,7 +32,7 @@
 
 	<properties>
 		<mixpanel.version>1.4.4</mixpanel.version>
-		<org.json.version>20230227</org.json.version>
+		<org.json.version>20231013</org.json.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 

--- a/cql-wih/pom.xml
+++ b/cql-wih/pom.xml
@@ -32,7 +32,7 @@
 
 	<properties>
 		<mixpanel.version>1.4.4</mixpanel.version>
-		<org.json.version>20230227</org.json.version>
+		<org.json.version>20231013</org.json.version>
 		<jackson-databind.version>2.13.5</jackson-databind.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -12,7 +12,7 @@
 	<properties>
 		<cxf.version>3.5.5</cxf.version>
 		<mixpanel.version>1.4.4</mixpanel.version>
-		<org.json.version>20230227</org.json.version>
+		<org.json.version>20231013</org.json.version>
 		<ant.version>1.10.11</ant.version>
 		<jsoup.version>1.15.3</jsoup.version>
 		<plexus-utils.version>3.5.0</plexus-utils.version>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -332,4 +332,11 @@
       <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-classworlds@.*$</packageUrl>
       <cve>CVE-2022-4245</cve>
    </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: json-20230227.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.json/json@.*$</packageUrl>
+      <cve>CVE-2023-5072</cve>
+   </suppress>
 </suppressions>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -332,11 +332,4 @@
       <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-classworlds@.*$</packageUrl>
       <cve>CVE-2022-4245</cve>
    </suppress>
-   <suppress>
-      <notes><![CDATA[
-      file name: json-20230227.jar
-      ]]></notes>
-      <packageUrl regex="true">^pkg:maven/org\.json/json@.*$</packageUrl>
-      <cve>CVE-2023-5072</cve>
-   </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -633,7 +633,7 @@
 			<plugin>
 				<groupId>org.owasp</groupId>
 				<artifactId>dependency-check-maven</artifactId>
-				<version>8.1.1</version>
+				<version>8.4.1</version>
 				<configuration>
 					<skipProvidedScope>true</skipProvidedScope>
 					<skipRuntimeScope>true</skipRuntimeScope>


### PR DESCRIPTION
- Removed suppression from json-20230227.jar
- Updated to the latest json-20231013.jar
- Updated the dependency-check-maven to 8.4.1 
- Vulnerability json-20230227.jar mitigated successfully