### PR TITLE
Mitigate dependency vulnerability in a2d2: jose4j-0.7.11.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<apiguardian.version>1.1.2</apiguardian.version>
 		<netty.version>4.1.94.Final</netty.version>
 		<mixpanel.version>1.4.4</mixpanel.version>
-		<wildfly-elytron.version>2.0.0.Final</wildfly-elytron.version>
+		<wildfly-elytron.version>2.2.2.Final</wildfly-elytron.version>
 		<org.json.version>20220924</org.json.version>
 		<commons-text.version>1.10.0</commons-text.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION

- Updated the  `wildfly-elytron` dependency to  the latest version.
- Successfully mitigated the `jose4j` vulnerability.
- Ran mvn site on local & verified vulnerability is mitigated successfully.


