### PR TITLE
Mitigate dependency vulnerability in a2d2:tomcat-embed-core 9.0.75

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -39,10 +39,10 @@
 		<jasypt.version>3.0.3</jasypt.version>
 		<commons-io.version>2.11.0</commons-io.version>
 		<maven.version>3.8.4</maven.version>
-		<tomcat-embed-websocket.version>9.0.75</tomcat-embed-websocket.version>
+		<tomcat-embed-websocket.version>9.0.82</tomcat-embed-websocket.version>
 		<spring.version>5.3.27</spring.version>
 		<resteasy-client.version>4.7.9.Final</resteasy-client.version>
-		<tomcat-embed-core.version>9.0.75</tomcat-embed-core.version>
+		<tomcat-embed-core.version>9.0.82</tomcat-embed-core.version>
 		<log4j.version>2.17.2</log4j.version>
 		<logback-classic.version>1.2.10</logback-classic.version>
 		<logback-core.version>1.2.9</logback-core.version>
@@ -749,4 +749,3 @@
 		</plugins>
 	</reporting>
 </project>
-

--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -27,7 +27,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.12</version>
+		<version>2.7.17</version>
 		<relativePath />
 	</parent>
 
@@ -40,7 +40,7 @@
 		<commons-io.version>2.11.0</commons-io.version>
 		<maven.version>3.8.4</maven.version>
 		<tomcat-embed-websocket.version>9.0.82</tomcat-embed-websocket.version>
-		<spring.version>5.3.27</spring.version>
+		<spring.version>5.3.30</spring.version>
 		<resteasy-client.version>4.7.9.Final</resteasy-client.version>
 		<tomcat-embed-core.version>9.0.82</tomcat-embed-core.version>
 		<log4j.version>2.17.2</log4j.version>

--- a/cds-hook-services/pom.xml
+++ b/cds-hook-services/pom.xml
@@ -35,7 +35,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-parent</artifactId>
-				<version>2.7.12</version>
+				<version>2.7.17</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -415,6 +415,14 @@
 					<groupId>org.yaml</groupId>
 					<artifactId>snakeyaml</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.tomcat.embed</groupId>
+    				<artifactId>tomcat-embed-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.tomcat.embed</groupId>
+    				<artifactId>tomcat-embed-websocket</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
@@ -575,4 +583,3 @@
 		<version>0.0.9-SNAPSHOT</version>
 	</parent>
 </project>
-

--- a/kie-based-services/pom.xml
+++ b/kie-based-services/pom.xml
@@ -415,14 +415,6 @@
 					<groupId>org.yaml</groupId>
 					<artifactId>snakeyaml</artifactId>
 				</exclusion>
-				<exclusion>
-					<groupId>org.apache.tomcat.embed</groupId>
-    				<artifactId>tomcat-embed-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.tomcat.embed</groupId>
-    				<artifactId>tomcat-embed-websocket</artifactId>
-				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
 		<hapi.fhir.utilities.version>5.5.7</hapi.fhir.utilities.version>
 		<json-simple.version>1.1.1</json-simple.version>
 		<hibernate.version>5.4.24.Final</hibernate.version>
-		<spring.boot.starter.version>2.7.12</spring.boot.starter.version>
-		<spring.version>5.3.27</spring.version>
+		<spring.boot.starter.version>2.7.17</spring.boot.starter.version>
+		<spring.version>5.3.30</spring.version>
 		<jackson.version.databind>2.13.5</jackson.version.databind>
 		<jackson.version>2.13.5</jackson.version>
 		<protobuf-java.version>3.21.8</protobuf-java.version>

--- a/service-daos/pom.xml
+++ b/service-daos/pom.xml
@@ -30,7 +30,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-parent</artifactId>
-				<version>2.7.12</version>
+				<version>2.7.17</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
- Updated the `tomcat-embed-core` and `tomcat-embed-websocket` dependency to **9.0.82** version
- Successfully mitigated the `tomcat-embed-core` vulnerability.
- Ran mvn site on local & verified vulnerability is mitigated successfully.