### PR TITLE
Mitigate dependency vulnerability in a2d2: bcprov-jdk15on-1.69.jar

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -297,9 +297,9 @@
 			<version>${internal.deps.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk15on</artifactId>
-			<version>1.69</version>
+		    <groupId>org.bouncycastle</groupId>
+		    <artifactId>bcprov-jdk18on</artifactId>
+		    <version>1.74</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -297,9 +297,9 @@
 			<version>${internal.deps.version}</version>
 		</dependency>
 		<dependency>
-		    <groupId>org.bouncycastle</groupId>
-		    <artifactId>bcprov-jdk18on</artifactId>
-		    <version>1.74</version>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcprov-jdk18on</artifactId>
+			<version>1.74</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
- Updated the `bcprov-jdk18on` dependency  to 1.74 version
- Successfully mitigated the `bcprov-jdk15on` vulnerability.
- Ran mvn site on local & verified vulnerability is mitigated successfully.