### PR TITLE
Mitigate dependency vulnerability in a2d2: spring-security-config-5.7.10.jar

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -53,7 +53,7 @@
 		<aws-java-sdk.version>1.12.334</aws-java-sdk.version>
 		<joda-time.version>2.10.6</joda-time.version>
 		<jdk.version>11</jdk.version>
-		<spring-security.version>5.7.10</spring-security.version>
+		<spring-security.version>5.8.8</spring-security.version>
 		<postgresql.version>42.5.1</postgresql.version>
 		<cloudwatchlogbackappender.version>2.1</cloudwatchlogbackappender.version>
 		<mysql-connector-java.version>8.0.31</mysql-connector-java.version>	


### PR DESCRIPTION
- Updated the `spring-security`  version to 5.8.8 
- Successfully mitigated the `spring-security-config` vulnerability.
- Ran mvn site on local & verified vulnerability is mitigated successfully.