### PR TITLE
Mitigate dependency vulnerability in a2d2: logback-core-1.2.9.jar

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -45,7 +45,7 @@
 		<tomcat-embed-core.version>9.0.82</tomcat-embed-core.version>
 		<log4j.version>2.17.2</log4j.version>
 		<logback-classic.version>1.2.10</logback-classic.version>
-		<logback-core.version>1.2.9</logback-core.version>
+		<logback-core.version>1.2.13</logback-core.version>
 		<checker-qual.version>3.33.0</checker-qual.version>
 		<kotlin-stdlib.version>1.6.21</kotlin-stdlib.version>
 		<okio.version>3.4.0</okio.version>


### PR DESCRIPTION
Mitigated logback-core-1.2.9.jar vulnerability by updating version to 1.2.13.
- Tested by running application on local