### PR TITLE
Mitigate dependency vulnerability in a2d2: logback-core-1.2.12.jar

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -332,4 +332,18 @@
       <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-classworlds@.*$</packageUrl>
       <cve>CVE-2022-4245</cve>
    </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: logback-core-1.2.12.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-core@.*$</packageUrl>
+      <cve>CVE-2023-6378</cve>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: logback-core-1.2.12.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-core@.*$</packageUrl>
+      <cve>CVE-2023-6481</cve>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
Mitigated vulnerability logback-core-1.2.12.jar by adding suppression
- Verified by generating report by mvn site.