### PR TITLE
Mitigate dependency vulnerability in a2d2: logback-classic-1.2.10.jar

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -346,4 +346,18 @@
       <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-core@.*$</packageUrl>
       <cve>CVE-2023-6481</cve>
    </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: logback-classic-1.2.12.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-classic@.*$</packageUrl>
+      <cve>CVE-2023-6378</cve>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      file name: logback-classic-1.2.12.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/ch\.qos\.logback/logback\-classic@.*$</packageUrl>
+      <cve>CVE-2023-6481</cve>
+   </suppress>
 </suppressions>


### PR DESCRIPTION
- Mitigated vulnerability `logback-classic-1.2.10.jar` by adding suppression.
- The vulnerability is due to serialization vulnerability in logback receiver component allows an attacker to mount a Denial-Of-Service attack by sending poisoned data.
- This dependency `logback-classic-1.2.10.jar`  comes under spring-boot-starter so we  are not directly vulnerable for this dependency.
- When updated spring-boot-starter to the latest version the `logback-classic` vulnerability still exists so I have added the suppression
-  I have added the links to reference,
    - [News](https://logback.qos.ch/news.html#1.3.12) 
    - [NVD - CVE-2023-6378](https://nvd.nist.gov/vuln/detail/CVE-2023-6378)
    - [NVD - CVE-2023-6481](https://nvd.nist.gov/vuln/detail/CVE-2023-6481)
    
    
[dependency-check-report.pdf](https://github.com/elimuinformatics/a2d2/files/13659020/dependency-check-report.pdf)