### PR TITLE
Mitigate dependency vulnerability in a2d2: tomcat-embed-core-9.0.82.jar

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -27,7 +27,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.17</version>
+		<version>2.7.18</version>
 		<relativePath />
 	</parent>
 
@@ -39,10 +39,10 @@
 		<jasypt.version>3.0.3</jasypt.version>
 		<commons-io.version>2.11.0</commons-io.version>
 		<maven.version>3.8.4</maven.version>
-		<tomcat-embed-websocket.version>9.0.82</tomcat-embed-websocket.version>
-		<spring.version>5.3.30</spring.version>
+		<tomcat-embed-websocket.version>9.0.83</tomcat-embed-websocket.version>
+		<spring.version>5.3.31</spring.version>
 		<resteasy-client.version>4.7.9.Final</resteasy-client.version>
-		<tomcat-embed-core.version>9.0.82</tomcat-embed-core.version>
+		<tomcat-embed-core.version>9.0.83</tomcat-embed-core.version>
 		<log4j.version>2.17.2</log4j.version>
 		<logback-classic.version>1.2.10</logback-classic.version>
 		<logback-core.version>1.2.13</logback-core.version>

--- a/cds-hook-services/pom.xml
+++ b/cds-hook-services/pom.xml
@@ -35,7 +35,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-parent</artifactId>
-				<version>2.7.17</version>
+				<version>2.7.18</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
 		<hapi.fhir.utilities.version>5.5.7</hapi.fhir.utilities.version>
 		<json-simple.version>1.1.1</json-simple.version>
 		<hibernate.version>5.4.24.Final</hibernate.version>
-		<spring.boot.starter.version>2.7.17</spring.boot.starter.version>
-		<spring.version>5.3.30</spring.version>
+		<spring.boot.starter.version>2.7.18</spring.boot.starter.version>
+		<spring.version>5.3.31</spring.version>
 		<jackson.version.databind>2.13.5</jackson.version.databind>
 		<jackson.version>2.13.5</jackson.version>
 		<protobuf-java.version>3.21.8</protobuf-java.version>

--- a/service-daos/pom.xml
+++ b/service-daos/pom.xml
@@ -30,7 +30,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-parent</artifactId>
-				<version>2.7.17</version>
+				<version>2.7.18</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
- Updated the `spring-boot-starter-parent` version to 2.7.18
- Updated the `spring-version` to 3.5.31
- Also updated the `tomcat-embed-core` version to 9.0.83
- Successfully mitigated the `tomcat-embed-core` vulnerability.
- Ran mvn site on local & verified vulnerability is mitigated successfully.

[dependency-check-report.pdf](https://github.com/elimuinformatics/a2d2/files/13769514/dependency-check-report.pdf)
