### PR TITLE
Mitigate dependency vulnerability in a2d2: netty-transport-4.1.94.Final.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 		<log4j.version>2.17.2</log4j.version>
 		<junit-platform-commons.version>1.8.2</junit-platform-commons.version>
 		<apiguardian.version>1.1.2</apiguardian.version>
-		<netty.version>4.1.94.Final</netty.version>
+		<netty.version>4.1.104.Final</netty.version>
 		<mixpanel.version>1.4.4</mixpanel.version>
 		<wildfly-elytron.version>2.2.2.Final</wildfly-elytron.version>
 		<org.json.version>20220924</org.json.version>


### PR DESCRIPTION
- Updated the `netty-version` to 4.1.104.Final
- Successfully mitigated the netty-transport vulnerability.
- Ran mvn site on local & verified vulnerability is mitigated successfully.


[dependency-check-report.pdf](https://github.com/elimuinformatics/a2d2/files/13803711/dependency-check-report.2.pdf)
