### PR TITLE
Mitigate dependency vulnerability in a2d2: postgresql-42.5.1.jar

### DIFF
--- a/a2d2-api/pom.xml
+++ b/a2d2-api/pom.xml
@@ -54,7 +54,7 @@
 		<joda-time.version>2.10.6</joda-time.version>
 		<jdk.version>11</jdk.version>
 		<spring-security.version>5.7.10</spring-security.version>
-		<postgresql.version>42.5.1</postgresql.version>
+		<postgresql.version>42.7.3</postgresql.version>
 		<cloudwatchlogbackappender.version>2.1</cloudwatchlogbackappender.version>
 		<mysql-connector-java.version>8.0.31</mysql-connector-java.version>	
 		<snakeyaml.version>1.33</snakeyaml.version>


### PR DESCRIPTION
- Updated the postgresql version to 42.7.3
- Successfully mitigated the postgresql vulnerability.
- Ran mvn site on local & verified vulnerability is mitigated successfully.